### PR TITLE
Switch to weak_framework in podspec

### DIFF
--- a/CardScan.podspec
+++ b/CardScan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CardScan'
-  s.version          = '1.0.4042'
+  s.version          = '1.0.4043'
   s.summary          = 'Scan credit cards'
   s.description      = <<-DESC
 CardScan is a library for scanning credit cards.
@@ -18,13 +18,13 @@ CardScan is a library for scanning credit cards.
   s.subspec 'Core' do |core|
     core.source_files = 'CardScan/Classes/**/*'
     core.resources = ['CardScan/Assets/*.xcassets', 'CardScan/Assets/*.storyboard']
-    core.frameworks = 'AVKit', 'CoreML', 'VideoToolbox', 'Vision', 'UIKit', 'AVFoundation'
+    core.weak_frameworks = 'AVKit', 'CoreML', 'VideoToolbox', 'Vision', 'UIKit', 'AVFoundation'
   end
 
   s.subspec 'Stripe' do |stripe|
     stripe.source_files = 'CardScan/Classes/**/*'
     stripe.resources = ['CardScan/Assets/*.xcassets', 'CardScan/Assets/*.storyboard']
-    stripe.frameworks = 'AVKit', 'CoreML', 'VideoToolbox', 'Vision', 'UIKit', 'AVFoundation'
+    stripe.weak_frameworks = 'AVKit', 'CoreML', 'VideoToolbox', 'Vision', 'UIKit', 'AVFoundation'
     stripe.dependency  'Stripe'
   end
 end

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -55,7 +55,7 @@ import Vision
 
 @objc public class ScanViewController: UIViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
     
-    public var scanDelegate: ScanDelegate?
+    public weak var scanDelegate: ScanDelegate?
     public var allowSkip = false
     public var scanQrCode = false
     public var errorCorrectionDuration = 1.5

--- a/Example/CardScan.xcodeproj/project.pbxproj
+++ b/Example/CardScan.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-CardScan_Example/Pods-CardScan_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-CardScan_Example/Pods-CardScan_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CardScan/CardScan.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -227,7 +227,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CardScan_Example/Pods-CardScan_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-CardScan_Example/Pods-CardScan_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D9DEC8987AE09D0E1D04249B /* [CP] Check Pods Manifest.lock */ = {
@@ -393,7 +393,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = L4TQ6C2R74;
 				INFOPLIST_FILE = CardScan/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getgrowthmetrics.CardScan-Example";
@@ -411,7 +411,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = L4TQ6C2R74;
 				INFOPLIST_FILE = CardScan/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.getgrowthmetrics.CardScan-Example";


### PR DESCRIPTION
Use lazy framework loading so that older versions of iOS can still operate if they use cardscan. Also, changes the scan delegate to a weak reference to avoid circular reference.