### PR TITLE
Moved mask setup to viewWillAppear() to patch race condition

### DIFF
--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -260,11 +260,6 @@ import Vision
         
         self.videoFeed.requestCameraAccess()
         self.previewView.videoPreviewLayer.session = self.videoFeed.session
-        self.videoFeed.setup(captureDelegate: self) { success in
-            if success {
-                self.setupMask()
-            }
-        }
     }
     
     override public var shouldAutorotate: Bool {
@@ -281,6 +276,13 @@ import Vision
     
     override public func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
+        self.videoFeed.setup(captureDelegate: self) { success in
+            if success {
+                self.setupMask()
+            }
+        }
+        
         self.videoFeed.willAppear()
         self.isNavigationBarHidden = self.navigationController?.isNavigationBarHidden ?? true
         self.navigationController?.setNavigationBarHidden(true, animated: animated)


### PR DESCRIPTION
- Fix affects slower devices that have trouble loading certain UI components after `viewDidLoad()` but before `viewWillAppear()`