### PR TITLE
Remove calledDelegate check for cancel and skip

### DIFF
--- a/CardScan.podspec
+++ b/CardScan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CardScan'
-  s.version          = '1.0.4058'
+  s.version          = '1.0.4059'
   s.summary          = 'Scan credit cards'
   s.description      = <<-DESC
 CardScan is a library for scanning credit cards.

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -185,18 +185,17 @@ import Vision
     }
     
     @IBAction func backButtonPress(_ sender: Any) {
-        if self.calledDelegate {
-            return
-        }
+        // Note: for the back button we may call the `userCancelled` delegate even if the
+        // delegate has been called just as a safety precation to always provide the
+        // user with a way to get out.
         self.ocr.userCancelled()
         self.calledDelegate = true
         self.scanDelegate?.userDidCancel(self)
     }
     
     @IBAction func skipButtonPress() {
-        if self.calledDelegate {
-            return
-        }
+        // Same for the skip button, like with the back button press we may call the
+        // delegate function even if it's already been called
         self.ocr.userCancelled()
         self.calledDelegate = true
         self.scanDelegate?.userDidSkip(self)


### PR DESCRIPTION
As a safety precaution we removed the check to see if the delegate has already been called when the user presses the back button. This means that that method may be invoked multiple times and it could be invoked even after a successful scan, but it does make sure that we always have an out.