### PR TITLE
Expose camera start function

### DIFF
--- a/CardScan.podspec
+++ b/CardScan.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CardScan'
-  s.version          = '1.0.4064'
+  s.version          = '1.0.4065'
   s.summary          = 'Scan credit cards'
   s.description      = <<-DESC
 CardScan is a library for scanning credit cards.

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -171,9 +171,9 @@ import Vision
         regionOfInterestLabel.layer.borderColor = UIColor.white.cgColor
         regionOfInterestLabel.layer.borderWidth = 2.0
         self.ocr.errorCorrectionDuration = self.errorCorrectionDuration
-        
-        self.videoFeed.requestCameraAccess()
         self.previewView?.videoPreviewLayer.session = self.videoFeed.session
+        
+        self.videoFeed.pauseSession()
     }
     
     override open var shouldAutorotate: Bool {

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -158,6 +158,12 @@ import Vision
         self.previewView?.addSubview(cornersView)
     }
     
+    // you must call setupOnViewDidLoad before calling this function and you have to call
+    // this function to get the camera going
+    public func startCameraPreview() {
+        self.videoFeed.requestCameraAccess()
+    }
+    
     public func setupOnViewDidLoad(regionOfInterestLabel: UILabel, blurView: UIView, previewView: PreviewView, debugImageView: UIImageView?) {
         
         self.regionOfInterestLabel = regionOfInterestLabel

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -196,7 +196,7 @@ import UIKit
         
         let debugImageView = self.showDebugImageView ? self.debugImageView : nil
         self.setupOnViewDidLoad(regionOfInterestLabel: self.regionOfInterestLabel, blurView: self.blurView, previewView: self.previewView, debugImageView: debugImageView)
-        self.videoFeed.requestCameraAccess()
+        self.startCameraPreview()
     }
     
     override public func showCardNumber(_ number: String, expiry: String?) {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -196,6 +196,7 @@ import UIKit
         
         let debugImageView = self.showDebugImageView ? self.debugImageView : nil
         self.setupOnViewDidLoad(regionOfInterestLabel: self.regionOfInterestLabel, blurView: self.blurView, previewView: self.previewView, debugImageView: debugImageView)
+        self.videoFeed.requestCameraAccess()
     }
     
     override public func showCardNumber(_ number: String, expiry: String?) {

--- a/CardScan/Classes/VideoFeed.swift
+++ b/CardScan/Classes/VideoFeed.swift
@@ -17,14 +17,17 @@ class VideoFeed {
     
     var torch: Torch?
     
+    func pauseSession() {
+        self.sessionQueue.suspend()
+    }
+    
     func requestCameraAccess() {
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
-            // The user has previously granted access to the camera.
+            self.sessionQueue.resume()
             break
             
         case .notDetermined:
-            self.sessionQueue.suspend()
             AVCaptureDevice.requestAccess(for: .video, completionHandler: { granted in
                 if !granted {
                     self.setupResult = .notAuthorized


### PR DESCRIPTION
This PR sets up the base view controller so that it starts in a paused state by default and any classes that inherit from it need to explicitly start the camera by calling the `startCameraPreview` method. The ScanViewController does this during `didLoad` but other VCs can do this later if they choose.