### PR TITLE
Drop iPhone 6 and older using a device blacklist

### DIFF
--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -92,7 +92,13 @@ import Vision
     
     @objc static public func isCompatible() -> Bool {
         if #available(iOS 11.2, *) {
-            return true
+            // make sure that we don't run on iPhone 6 / 6plus or older
+            switch Api.deviceType() {
+            case "iPhone3,1", "iPhone3,2", "iPhone3,3", "iPhone4,1", "iPhone5,1", "iPhone5,2", "iPhone5,3", "iPhone5,4", "iPhone6,1", "iPhone6,2", "iPhone7,2", "iPhone7,1":
+                return false
+            default:
+                return true
+            }
         } else {
             return false
         }


### PR DESCRIPTION
The GPU on iPhone 6 and iPhone 6 Plus are too slow to support our machine learning models efficiently, so we're dropping them from our supported hardware. We should also investigate iPad and iPod touch later, but for now this is good enough.

I tested this using our Firebase TestLab setup and confirmed that iPhone6 is not supported but all newer devices are.

https://console.firebase.google.com/project/bouncer-card-scan/testlab/histories/bh.1247d8283144895c/matrices/6344922426939065259