### PR TITLE
Remove unused debug data

### DIFF
--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -30,11 +30,7 @@ public class Ocr {
                                                 numberBoxes: boxes,
                                                 number: number,
                                                 cvvBoxes: cvvBoxes)
-        self.scanStats.backgroundImageJpeg = predictionResult.backgroundImageJpeg(originalImage: image)
         self.scanStats.bin = predictionResult.bin()
-        self.scanStats.binImagePng = predictionResult.binImagePng(originalImage: image)
-        self.scanStats.last4 = predictionResult.last4()
-        self.scanStats.last4ImagePng = predictionResult.last4ImagePng(originalImage: image)
         
         let xMin = boxes.map { $0.minX }.min() ?? 0
         let xMax = boxes.map { $0.maxX }.max() ?? 0

--- a/CardScan/Classes/PredictionResult.swift
+++ b/CardScan/Classes/PredictionResult.swift
@@ -53,22 +53,6 @@ struct PredictionResult {
             return nil
         #endif
     }
-        
-    func binImagePng(originalImage: CGImage) -> String? {
-        let boxes = translateNumber(to: originalImage)
-        guard let box = boxes.prefix(1).first else {
-            return nil
-        }
-        return extractImagePng(from: originalImage, for: box)
-    }
-    
-    func last4ImagePng(originalImage: CGImage) -> String? {
-        let boxes = translateNumber(to: originalImage)
-        guard let box = boxes.suffix(1).first else {
-            return nil
-        }
-        return extractImagePng(from: originalImage, for: box)
-    }
     
     func resizeImage(image: UIImage, to size: CGSize) -> UIImage? {
         UIGraphicsBeginImageContext(CGSize(width: size.width, height: size.height))
@@ -77,52 +61,5 @@ struct PredictionResult {
         UIGraphicsEndImageContext()
         
         return newImage
-    }
-    
-    func backgroundImageJpeg(originalImage: CGImage) -> String? {
-        guard let resizedImage = self.resizeImage(image: UIImage(cgImage:originalImage), to: CGSize(width: 600, height: 378)) else {
-            print("couldn't resize image")
-            return nil
-        }
-        
-        guard let cgImage = resizedImage.cgImage else {
-            print("no cgImage")
-            return nil
-        }
-        
-        let boxes = self.translateNumber(to: cgImage)
-        let xmin = boxes.map { $0.minX }.min() ?? 0.0
-        let ymin = boxes.map { $0.minY }.min() ?? 0.0
-        let xmax = boxes.map { $0.maxX }.max() ?? CGFloat(cgImage.width)
-        let ymax = boxes.map { $0.maxY }.max() ?? CGFloat(cgImage.height)
-        
-        let box = CGRect(x: xmin, y: ymin, width: xmax - xmin, height: ymax - ymin)
-        
-        let imageSize = CGSize(width: cgImage.width, height: cgImage.height)
-        let scale: CGFloat = 0
-        UIGraphicsBeginImageContextWithOptions(imageSize, false, scale)
-        
-        resizedImage.draw(at: CGPoint(x: 0,y :0))
-        UIColor.black.setStroke()
-        UIColor.black.setFill()
-        
-        UIRectFill(box)
-    
-        let originalImageSize = CGSize(width: originalImage.width, height: originalImage.height)
-        for cvvBox in PredictionResult.translateBoxes(from: originalImageSize, to: resizedImage.size, for: self.cvvBoxes) {
-            UIRectFill( cvvBox)
-        }
-        
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        #if swift(>=4.2)
-            let uiImage = newImage?.cgImage.map { UIImage(cgImage: $0) }
-            return uiImage?.jpegData(compressionQuality: 0.75)?.base64EncodedString()
-        #else
-            // just to make the compiler happy
-            let _ = newImage?.cgImage.map { UIImage(cgImage: $0) }
-            return nil
-        #endif
     }
 }

--- a/CardScan/Classes/ScanStats.swift
+++ b/CardScan/Classes/ScanStats.swift
@@ -19,11 +19,7 @@ public struct ScanStats {
     public var endTime: Date?
     public var model: String?
     public var algorithm: String?
-    public var binImagePng: String?
     public var bin: String?
-    public var last4ImagePng: String?
-    public var last4: String?
-    public var backgroundImageJpeg: String?
     public var lastFlatBoxes: [CGRect]?
     public var lastEmbossedBoxes: [CGRect]?
     public var deviceType: String?
@@ -50,24 +46,6 @@ public struct ScanStats {
         self.deviceType = deviceType
     }
     
-    public func toDictionaryForServer() -> [String: Any] {
-        return ["scans": self.scans,
-                "flat_digits_recognized": self.flatDigitsDetected,
-                "flat_digits_detected": self.flatDigitsDetected,
-                "embossed_digits_recognized": self.embossedDigitsRecognized,
-                "embossed_digits_detected": self.embossedDigitsDetected,
-                "torch_on": self.torchOn,
-                "success": self.success ?? false,
-                "duration": self.duration(),
-                "model": self.model ?? "unknown",
-                "bin": self.bin ?? "",
-                "bin_image_png": self.binImagePng ?? "",
-                "last4": self.last4 ?? "",
-                "last4_image_png": self.last4ImagePng ?? "",
-                "background_image_jpeg": self.backgroundImageJpeg ?? "",
-                "device_type": self.deviceType ?? ""]
-    }
-    
     public func toDictionaryForAnalytics() -> [String: Any] {
         return ["scans": self.scans,
                 "cards_detected": self.cardsDetected,
@@ -92,27 +70,5 @@ public struct ScanStats {
         }
         
         return Data(base64Encoded: string).flatMap { UIImage(data: $0) }
-    }
-    
-    // helper functions for debugging
-    public func backgroundImage() -> UIImage? {
-        return self.image(from: self.backgroundImageJpeg)
-    }
-    
-    public func binImage() -> UIImage? {
-        return self.image(from: self.binImagePng)
-    }
-    
-    public func last4Image() -> UIImage? {
-        return self.image(from: self.last4ImagePng)
-    }
-    
-    public func imagesSize() -> Int {
-        var size = 0
-        size += self.backgroundImageJpeg?.count ?? 0
-        size += self.last4ImagePng?.count ?? 0
-        size += self.binImagePng?.count ?? 0
-        
-        return size
     }
 }

--- a/Example/CardScan/ResultViewController.swift
+++ b/Example/CardScan/ResultViewController.swift
@@ -25,18 +25,10 @@ class ResultViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        guard let scanStats = self.scanStats else {
-            return
-        }
         
         if let image = self.cardImage {
             self.backgroundImage.image = image
-        } else {
-            self.backgroundImage.image = scanStats.backgroundImage()
         }
-        self.bin0.image = scanStats.binImage()
-        self.last0.image = scanStats.last4Image()
       
         self.numberLabel.text = format(number: self.number ?? "")
         self.expirationLabel.text = expiration ?? ""


### PR DESCRIPTION
Removes some of our debugging information including:

- An image of the card with the PAN blacked out
- An image of the BIN
- An image of the last4

These were only being used by an internal testing app, so it should have no impact on production code.