### PR TITLE
mini bug @ viewwillappear

### DIFF
--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -191,12 +191,10 @@ import Vision
     
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        if self.ocr.numbers.count > 0 || self.ocr.expiries.count > 0 {
-            self.ocr.numbers.removeAll()
-            self.ocr.expiries.removeAll()
-            self.ocr.firstResult = nil
-        }
+
+        self.ocr.numbers.removeAll()
+        self.ocr.expiries.removeAll()
+        self.ocr.firstResult = nil
         self.calledOnScannedCard = false
         self.videoFeed.willAppear()
         self.isNavigationBarHidden = self.navigationController?.isNavigationBarHidden ?? true

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -192,7 +192,7 @@ import Vision
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        if self.ocr.numbers.count > 0 && self.ocr.expiries.count > 0 {
+        if self.ocr.numbers.count > 0 || self.ocr.expiries.count > 0 {
             self.ocr.numbers.removeAll()
             self.ocr.expiries.removeAll()
             self.ocr.firstResult = nil


### PR DESCRIPTION
the && in viewwillappear logic prevent the ocr data to be reset on the events where the expirations arent detected properly. 