### PR TITLE
Enable the library to optionally run on old devices

### DIFF
--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -104,9 +104,12 @@ import Vision
         NotificationCenter.default.addObserver(self, selector: #selector(didBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
     }
     
-    @objc static public func isCompatible() -> Bool {
+    @objc static public func isCompatible(runOnOldDevices: Bool = false) -> Bool {
         if #available(iOS 11.2, *) {
             // make sure that we don't run on iPhone 6 / 6plus or older
+            if runOnOldDevices {
+                return true
+            }
             switch Api.deviceType() {
             case "iPhone3,1", "iPhone3,2", "iPhone3,3", "iPhone4,1", "iPhone5,1", "iPhone5,2", "iPhone5,3", "iPhone5,4", "iPhone6,1", "iPhone6,2", "iPhone7,2", "iPhone7,1":
                 return false

--- a/CardScan/Classes/ScanConfiguration.swift
+++ b/CardScan/Classes/ScanConfiguration.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+@objc public class ScanConfiguration: NSObject {
+    @objc public var runOnOldDevices = false
+}

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -106,8 +106,13 @@ import UIKit
     var calledDelegate = false
     
     @objc static public func createViewController(withDelegate delegate: ScanDelegate? = nil) -> ScanViewController? {
+        // use default config
+        return self.createViewController(withDelegate: delegate, configuration: ScanConfiguration())
+    }
+    
+    @objc static public func createViewController(withDelegate delegate: ScanDelegate? = nil, configuration: ScanConfiguration) -> ScanViewController? {
         
-        if !self.isCompatible() {
+        if !self.isCompatible(runOnOldDevices: configuration.runOnOldDevices) {
             return nil
         }
         

--- a/Example/CardScan/Base.lproj/Main.storyboard
+++ b/Example/CardScan/Base.lproj/Main.storyboard
@@ -33,7 +33,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
-                                    <action selector="scanCardFakeOnly" destination="vXZ-lx-hvc" eventType="touchUpInside" id="dje-0L-2QO"/>
+                                    <action selector="scanCardPress" destination="vXZ-lx-hvc" eventType="touchUpInside" id="dje-0L-2QO"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6NY-p4-OvD">
@@ -114,11 +114,20 @@
                                     <action selector="scanWithStatsPress" destination="vXZ-lx-hvc" eventType="touchUpInside" id="jE8-iT-1in"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f3P-G8-yKq">
+                                <rect key="frame" x="119.5" y="189.5" width="136" height="30"/>
+                                <state key="normal" title="Scan on old phones"/>
+                                <connections>
+                                    <action selector="scanCardOldDevicePress" destination="vXZ-lx-hvc" eventType="touchUpInside" id="lSb-gT-iHT"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="qlz-Ds-Znv" firstAttribute="top" secondItem="9tR-DO-gyb" secondAttribute="bottom" constant="16" id="1PH-rJ-mXS"/>
+                            <constraint firstItem="ohs-2Q-mlC" firstAttribute="top" secondItem="f3P-G8-yKq" secondAttribute="bottom" constant="8" id="2fc-SR-27T"/>
                             <constraint firstItem="ohs-2Q-mlC" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="16" id="420-Q5-1Ny"/>
+                            <constraint firstItem="f3P-G8-yKq" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="8CR-et-Rxz"/>
                             <constraint firstItem="qlz-Ds-Znv" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="AkZ-f5-Cw0"/>
                             <constraint firstItem="LBI-Nj-Ojb" firstAttribute="top" secondItem="pIK-as-bko" secondAttribute="bottom" constant="8" id="DKk-6B-vtM"/>
                             <constraint firstItem="9tR-DO-gyb" firstAttribute="top" secondItem="ohs-2Q-mlC" secondAttribute="bottom" constant="8" id="Fjf-BO-ZHs"/>

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -79,8 +79,20 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, ScanStringsDat
         vc.scanQrCode = true
         self.present(vc, animated: true)
     }
-    @IBAction func scanCardFakeOnly() {
+    @IBAction func scanCardPress() {
         guard let vc = ScanViewController.createViewController(withDelegate: self) else {
+            print("scan view controller not supported on this hardware")
+            return
+        }
+        
+        vc.allowSkip = true
+        self.present(vc, animated: true)
+    }
+    
+    @IBAction func scanCardOldDevicePress() {
+        let config = ScanConfiguration()
+        config.runOnOldDevices = true
+        guard let vc = ScanViewController.createViewController(withDelegate: self, configuration: config) else {
             print("scan view controller not supported on this hardware")
             return
         }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -8,55 +8,56 @@
 
 /* Begin PBXBuildFile section */
 		03EF4CBFEDC172315F867978B4039321 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
-		094DF50A927EC0DC71DF3CB86085B0D4 /* BundleURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84B196E5F9DB0B72C7BE4CFB1A881CC /* BundleURL.swift */; };
-		0BCBFF0C01DDA1902A4E9029A7DCFB64 /* PredictionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BAA8E73C0D9D7D2E0BF820D635A888 /* PredictionAPI.swift */; };
+		0632DEE15D8B4034206057F88279D1C3 /* CGRectExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B530141DA2C85A30DF8D10662C4A2B /* CGRectExtension.swift */; };
 		0D2D8597A321C27975C5365670F3B208 /* Pods-CardScan_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9993926088E7489340DBB6602A45C25D /* Pods-CardScan_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10D63F8AC26E8BE3A9A22AF390B9063F /* CardScan.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7376E3957F2CEFE60CE359FAC4F9B229 /* CardScan.storyboard */; };
-		273DAC21E24A247ED89A744C46E6B67E /* CornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92DC7D1FC427323456D34C84421AAF4 /* CornerView.swift */; };
-		29B307C195B81B7E588547BF12B92D0E /* CreditCardUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E21CB6B34F3B677B3F1848599FBF02A /* CreditCardUtils.swift */; };
-		2A3C77561D64D25E0B4317FB958E72F2 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB432B71FA41CA2994D50A9F98B80 /* BlurView.swift */; };
-		32E4A4C5CA51CF8780FD8A2173FF430E /* ModelOutputExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778761861A24D24AC8F316E1ED85DEE1 /* ModelOutputExtensions.swift */; };
+		140DCE84C2C667121DC0219FF1CD61AB /* ScanEventsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98ED6E9C83923BC90124C910E6C5412 /* ScanEventsProtocol.swift */; };
+		156DA25F5D7967D1E71BCC3C92BD5B78 /* DetectedAllBoxes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C50F653EFB21A2E9525ADF1CCC5985A /* DetectedAllBoxes.swift */; };
+		1D7D1BD392873828D7FEA28BC5412DFA /* CreditCardUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B915CC18296B2F72989CB0FA8939D3 /* CreditCardUtils.swift */; };
+		2C5814DE9AE7ACA3B5784DD92E24D653 /* FindFourOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54239E7FF05E3E70C4CF43F4E1AFDB0 /* FindFourOcr.swift */; };
+		2FA7E7D67CC79C8F728FEA1327E79B5F /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE961F44D5CEA3DA5F25DDDFF4E7955 /* ScanViewController.swift */; };
+		3066FCBB356946D14BABDB26C0B51DBD /* GeneratedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AD17BA3C2BA094EA1BB48FCE382E6B /* GeneratedModels.swift */; };
 		331965C4B58E369437492E5724A52600 /* Pods-CardScan_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = BDE16F2D417E4B470FF336342C789E52 /* Pods-CardScan_Example-dummy.m */; };
-		3428161F561705938A8B745F2F08513E /* DetectedSSDBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37370DDF3E1AEA518EBF3E1D9F3DB901 /* DetectedSSDBox.swift */; };
-		37122C6A9ABF64FBDA30002A1890EFC2 /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97DCE401FD6C43421CAD8A74FF8F6DC5 /* PreviewView.swift */; };
-		371CFA1A3F67E9CE1D77F2B24E0B070C /* Ocr.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EEC78D590E0BCBFEB69A22F4964FB7 /* Ocr.swift */; };
-		3C58DA8B2FC4AA88A4C112B8CDCBE27B /* SSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426DF59AC8B6E137F970AFE5C2D465CB /* SSD.swift */; };
-		3ED9794A37A2856D05C8BE8966BCF2C0 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359C199804560EA9E70C8AB847B39CBA /* API.swift */; };
-		3F9153A9EA6478CA822A1E8F16C307C3 /* CardScan-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 34CA68A62F11D5A796569EF92C1567AC /* CardScan-dummy.m */; };
-		4F3E897A6FE1F22DCBB77F29503DC3C8 /* Expiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E180F58C5B06E52B3F6239EE57945158 /* Expiry.swift */; };
-		523B667BF8D1201E25DB2E3BE5707E7D /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C0695EB349D3989F608CD8B8C5483E /* AppState.swift */; };
-		5389BA3233573DA74A777D4473EC1B87 /* NMS.swift in Sources */ = {isa = PBXBuildFile; fileRef = B673A58D315C7296856EAD8CBF45D67F /* NMS.swift */; };
-		6020EF2D7D359B7B5167D4571D9ADC19 /* PostDetectionAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E651440496A1361460144ECBE7DA67 /* PostDetectionAlgorithm.swift */; };
-		60AD08C910BA9EF8DC12D7AE45E6C7F4 /* ScanStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ED19890CA254D5B6A8093198DF9EA3 /* ScanStats.swift */; };
-		6EC374D0FAA6302B5E41F4517BB4F481 /* ScanEventsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D074364BEED822E60E9BEE44CE78220E /* ScanEventsProtocol.swift */; };
+		3B6DDBCAF12F988DDB12406CB3106BEE /* CardScan.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0BBC9538B38236B253752CC3B1CD0DF0 /* CardScan.bundle */; };
+		3E75BE70CBFB676FDBABFCB407D2DA8E /* BundleURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66E6591F15807AFEAD91F80C1327604 /* BundleURL.swift */; };
+		42643B39F1A8ABD5D20B9DFC50CB95C0 /* FindFour.mlmodelc in Resources */ = {isa = PBXBuildFile; fileRef = 887792CBD80BBB0DC09A3C2CB2E27E11 /* FindFour.mlmodelc */; };
+		427DD17659DC11EA007E616DD43A9072 /* PostDetectionAlgorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEED44B35BCD836F3DA11C90A6CE22F5 /* PostDetectionAlgorithm.swift */; };
+		466B3EE8E2559D7F24C34AEAEDE031AF /* FourRecognize.mlmodelc in Resources */ = {isa = PBXBuildFile; fileRef = B3BF8EBC28AFA91ADF898B2E748A8526 /* FourRecognize.mlmodelc */; };
+		519A0BA0EEC2ABC21AAC2CA2851FA356 /* PriorsGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FCEB0408CF28FB08DC5FF27181C50B /* PriorsGen.swift */; };
+		54A6E32A688D0E8B03E6E7ADF4E6AD74 /* PredictionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5906FA8937A733DAACECF1E53CE67F07 /* PredictionResult.swift */; };
+		5B1F49452BD0CBEF2015FFB4E5385CAC /* PredictionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5A43AB65D96563B851B8B1CDE6549F /* PredictionAPI.swift */; };
+		61F1859D0E9614BEF9A2500B34651585 /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F091605D8CEA6BF6BA04CD1BF87EA55A /* PreviewView.swift */; };
+		62B4493A60BA797583313328E288301F /* Torch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9832415F4370CFC8C705B134EF5473 /* Torch.swift */; };
+		674AB131358CF84C1DC70B11F5085F2C /* CardScan.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ED59CA8606A8D743208CAB1BA734E6C4 /* CardScan.storyboard */; };
+		6D567BA9C1C1709F11D10D0C3E785E70 /* RecognizedDigits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BDAF1773F173A18F825B02717BA3874 /* RecognizedDigits.swift */; };
+		75575406017868093FCA48B37BB75E83 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 578A72E94737B49C6F188F0870E9736C /* Assets.xcassets */; };
 		798E430EEC70011966BBFD257DC2FBD4 /* Pods-CardScan_ExampleTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F08E0F9D8B225015E5F2BFE5EC7D035 /* Pods-CardScan_ExampleTests-dummy.m */; };
-		9422AEA1EAEBBAACC800BC8D1FED8729 /* DetectedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16688A44D245E396D7598891A32C391 /* DetectedBox.swift */; };
-		94AD0AC63B0B33132CBE1CEDF98888EF /* FindFourOcr.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C59D78C14F1100B73AE0A33B8A160B /* FindFourOcr.swift */; };
+		867A71A7FF8DD359879EC0EC991F0BF6 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABAC670D7994878BB8DA83B5648953A /* API.swift */; };
+		9149C69E5E95131E546C79E739456ADA /* CardScan-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = AC336A09602F971886DF7F70045BF398 /* CardScan-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94C4F51292B9ECD71F3D674FC6869613 /* ScanConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E68A4ECE46F084543B54A63A45506E4 /* ScanConfiguration.swift */; };
 		975DB896FAA0CCF524293D3A20B7EF46 /* Pods-CardScan_ExampleUITests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D87B5E76D06D58DAAE6F6A81B2E8C91F /* Pods-CardScan_ExampleUITests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9AB912989633FC9A03F22FA0D5828F1F /* VideoFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2F4CA541F8C06D66D9FB925C2140690 /* VideoFeed.swift */; };
-		9B6018F4D0EB4763F979C71288B2FF96 /* SsdDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2A85176CFC02B60DE8CDB48943D636 /* SsdDetect.swift */; };
+		99A89BE96894506FBBA3AE124060A993 /* UIImage+pixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7CE6D5BE3ECA171502B7F367D430B3 /* UIImage+pixelBuffer.swift */; };
+		9AAFE69055E225D742EC96352BF7AB07 /* SSD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BDAD85A2C5AEEAFDB355C9CE37B486 /* SSD.swift */; };
+		9D132ED1DEAAA32B72782EEA2D33E97F /* ScanStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE64E0559DEC4346F06AD6E8E50AAB7 /* ScanStats.swift */; };
 		9D4B9A015097E91A5D9BAB2A7964BF34 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
-		9FABCD1C6DD1A2CA46D70F0EB8987346 /* PriorsGen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9F9D023C7C021E47752FB45347CC0C /* PriorsGen.swift */; };
-		A22C95B1B98DF3525C6DEE6350BA6263 /* RecognizedDigits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D249E7978AAF0F5D8D371A18536C92 /* RecognizedDigits.swift */; };
-		A7C9CBCD07A729285CB6B70854E13107 /* PredictionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2EA18398EA0489B76BA2911A057C0C /* PredictionResult.swift */; };
-		AF5985F346BFF4E6AAADA9CA36F9BD11 /* UIImage+pixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7BEB361AFC8DD00A4F33695347C2CD /* UIImage+pixelBuffer.swift */; };
-		C01A92989D46AE943EE14B8EB7453F9A /* Torch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A014265D7B8322076BC903FAB804C3CC /* Torch.swift */; };
+		A216113297134E9A1695C4025E491658 /* BlurView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3E9A0A1EB35A028C9E2CFCFCF83DCE /* BlurView.swift */; };
+		AC1126697B99FCA56337262DC0090AB4 /* ModelOutputExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F73458DBB4783F9898E57E5498C38F /* ModelOutputExtensions.swift */; };
+		B96FEC3CAEDF4CF7ECDE5EC2D5DB26BC /* Expiry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6124C0A0CECB72750894B5750C6C3FD4 /* Expiry.swift */; };
+		C178655A30B5B8DA5467BF41740C6B0C /* CardScan-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CF4A40D168C62F876367EBB057D89CB /* CardScan-dummy.m */; };
 		C2568A0540F73A2AC664CA17A3A07365 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
-		C536C3BBBCD807F15133FD4BA166C5F4 /* ScanBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1025D0CB83E1F183E3E9D5772B9ED1E /* ScanBaseViewController.swift */; };
-		C6A2913DDA5E0AE85222AE972238A36B /* SSDOutputExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EDDC53D9A6B3AF16F61EA38C8C4D76 /* SSDOutputExtensions.swift */; };
-		D331EC69905DF1BACD7806F55858FDD0 /* RecognizeNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AD27D38524BD53DCF1B446817D334E /* RecognizeNumbers.swift */; };
-		D9A20D606D607EB5D509F02E19FB8B2C /* CardScan-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC553DD501F0542789355885B135BE5 /* CardScan-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D9ACA84A95D668695B10E1FE2419691B /* ScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51631EC8B0986A93C716C12B361339FF /* ScanViewController.swift */; };
+		C82AC5582BBD95345B7B4A4DBFA0B2CB /* RecognizeNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F98D49B2E75DE652E23A3AA29A12D0A9 /* RecognizeNumbers.swift */; };
+		CAB9A81382969CCD005AF9905295F0AD /* SSDOutputExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDFDDFA8AE391401D49102D8FD66FA4 /* SSDOutputExtensions.swift */; };
+		CCC46F8CAF581D49148E1B45C545A167 /* DetectedBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C7248F43DB81343B1056F015483190 /* DetectedBox.swift */; };
+		D51787DB928BC969983094EA883B9E7A /* CornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E020D9739860F5BF1DCD9D4B32096B /* CornerView.swift */; };
+		D7CF5E7D127F5169AF905523659887CE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A9E17DBD29A2EF763AAAADD5625A13 /* AppState.swift */; };
 		D9C23335403455D2C73BE15A52D0B123 /* Pods-CardScan_ExampleTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A1308A9EE135E70590DD3E266C6CA700 /* Pods-CardScan_ExampleTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D9F2C8F4981831E154161D121B564DFF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
 		DBF656F52831440886C7B96A12349C04 /* Pods-CardScan_ExampleUITests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46DC03BD80E2956D4C1C6E7A463DF7CC /* Pods-CardScan_ExampleUITests-dummy.m */; };
-		DE8FC4964FDE2EEE89193F6CDD8E4B3A /* GeneratedModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8297603D1A867225A4D0E5E67C8DFAFC /* GeneratedModels.swift */; };
-		E4E6D4AE308D12AD740152A08922E515 /* FourRecognize.mlmodelc in Resources */ = {isa = PBXBuildFile; fileRef = 4D036A1E9A7A7F9D1A389F7D8A6D5A7D /* FourRecognize.mlmodelc */; };
-		E7542E353AF5FD0FEF86A05EA5D481EB /* FindFour.mlmodelc in Resources */ = {isa = PBXBuildFile; fileRef = DF8FBA3D14B4A50D12DDFF5B16338122 /* FindFour.mlmodelc */; };
-		EC2D2754FBA3601D3AE8BCD856F0CE66 /* CardScan.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0BBC9538B38236B253752CC3B1CD0DF0 /* CardScan.bundle */; };
-		ED5CCA52DCA821F5CAE7E2B241AFF7F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D10F172B3DF60D2A29DD095A5BAFC816 /* Assets.xcassets */; };
-		F14EF4502A88E6A7B9E8DA1FD4E64F65 /* DetectedAllBoxes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4570767FFE01C4B25A50BBA081797100 /* DetectedAllBoxes.swift */; };
-		FDE914C56D3772280415410B455D6F5F /* CGRectExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2BB1B31106DB442D30CB2BB35A84E6 /* CGRectExtension.swift */; };
+		DF47973DEF83664C4C09D7B46B35565E /* SsdDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D6232D66AB92C4E4EB2171181ACC0 /* SsdDetect.swift */; };
+		E990D6FDB01D95286A76060EABF3EBD3 /* Ocr.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FC561FE4C073D7A7324761474D973C /* Ocr.swift */; };
+		E9A13EAD83ECC08F1D80A1C61DEEE93D /* ScanBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB46B8AC753853ABFD98E793D4D6552 /* ScanBaseViewController.swift */; };
+		ED5CF31B07949FF539FAFAD14B38F8D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
+		F429DD4A64E1BEBCD728F2F7F000D54D /* VideoFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68ED150C8A308E2D1A4DE7A46A4CB6CF /* VideoFeed.swift */; };
+		F61938497B613355D66C9BB62B878DBC /* NMS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBC09763865822F7D4585D0FB6A547D /* NMS.swift */; };
+		F76320288A5BED28183B3C3CADA64A52 /* DetectedSSDBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A692EEAA502D49968CC9666A5119D1 /* DetectedSSDBox.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 992C704FCECE14F8E1B24C561D450C2E;
 			remoteInfo = "Pods-CardScan_Example";
+		};
+		667AF9ECE991055C591FB61297A3D541 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E28C2932ED4A11BBB17E34185D144C4E;
+			remoteInfo = "CardScan-CardScan";
 		};
 		71ABF33962AE7DC339FB60D9C9A51C7C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -80,13 +88,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7A35B702D709EA37681B6545A4E1EF1B;
 			remoteInfo = CardScan;
-		};
-		7F94C9A6DF7DCB1E36354718FE71062F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E28C2932ED4A11BBB17E34185D144C4E;
-			remoteInfo = "CardScan-CardScan";
 		};
 		9F05F9D52FB3B33DE87611287020C36A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -107,100 +108,94 @@
 /* Begin PBXFileReference section */
 		06DF56631CA88A5741553EC08132A46F /* Pods-CardScan_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CardScan_Example-frameworks.sh"; sourceTree = "<group>"; };
 		0BBC9538B38236B253752CC3B1CD0DF0 /* CardScan.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = CardScan.bundle; path = "CardScan-CardScan.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0D37C1388C6F78AFFF5406894BA7F7CF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		0C50F653EFB21A2E9525ADF1CCC5985A /* DetectedAllBoxes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedAllBoxes.swift; path = CardScan/Classes/DetectedAllBoxes.swift; sourceTree = "<group>"; };
+		10A692EEAA502D49968CC9666A5119D1 /* DetectedSSDBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedSSDBox.swift; path = CardScan/Classes/DetectedSSDBox.swift; sourceTree = "<group>"; };
 		13B1736F3BDF045B6A7DDF14BCBDE0CF /* Pods-CardScan_ExampleTests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CardScan_ExampleTests.modulemap"; sourceTree = "<group>"; };
-		148D2749B687D5C3320ED415CE470909 /* CardScan.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CardScan.modulemap; sourceTree = "<group>"; };
-		1BC553DD501F0542789355885B135BE5 /* CardScan-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CardScan-umbrella.h"; sourceTree = "<group>"; };
+		1C7CE6D5BE3ECA171502B7F367D430B3 /* UIImage+pixelBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIImage+pixelBuffer.swift"; path = "CardScan/Classes/UIImage+pixelBuffer.swift"; sourceTree = "<group>"; };
 		1E1205A84BB08EEF77BED3D66741ACAB /* Pods-CardScan_ExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_ExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		25E0AD106C7CB24570A566B44138AE31 /* Pods-CardScan_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		2E2BB1B31106DB442D30CB2BB35A84E6 /* CGRectExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CGRectExtension.swift; path = CardScan/Classes/CGRectExtension.swift; sourceTree = "<group>"; };
+		2A9832415F4370CFC8C705B134EF5473 /* Torch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Torch.swift; path = CardScan/Classes/Torch.swift; sourceTree = "<group>"; };
+		3135605ECEFA0B90989935FDC39C1C4C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		32B070D806DE6A2CE8251F2C9D12FE3A /* ResourceBundle-CardScan-CardScan-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-CardScan-CardScan-Info.plist"; sourceTree = "<group>"; };
-		34CA68A62F11D5A796569EF92C1567AC /* CardScan-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CardScan-dummy.m"; sourceTree = "<group>"; };
-		359C199804560EA9E70C8AB847B39CBA /* API.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = API.swift; path = CardScan/Classes/API.swift; sourceTree = "<group>"; };
-		37370DDF3E1AEA518EBF3E1D9F3DB901 /* DetectedSSDBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedSSDBox.swift; path = CardScan/Classes/DetectedSSDBox.swift; sourceTree = "<group>"; };
-		37D29DF722D4E03AF8AAE5F5D3E260ED /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		349723ABCDE7F7BA7308A774A2748940 /* CardScan.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = CardScan.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		34B915CC18296B2F72989CB0FA8939D3 /* CreditCardUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreditCardUtils.swift; path = CardScan/Classes/CreditCardUtils.swift; sourceTree = "<group>"; };
 		37D314FA58B718C8D1E4397DF28D3E92 /* Pods_CardScan_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CardScan_Example.framework; path = "Pods-CardScan_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3DE64E0559DEC4346F06AD6E8E50AAB7 /* ScanStats.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanStats.swift; path = CardScan/Classes/ScanStats.swift; sourceTree = "<group>"; };
+		3EE961F44D5CEA3DA5F25DDDFF4E7955 /* ScanViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanViewController.swift; path = CardScan/Classes/ScanViewController.swift; sourceTree = "<group>"; };
 		3F08E0F9D8B225015E5F2BFE5EC7D035 /* Pods-CardScan_ExampleTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CardScan_ExampleTests-dummy.m"; sourceTree = "<group>"; };
 		418724842C3DDFD867B7A3CBC8C8A2D3 /* Pods-CardScan_ExampleUITests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_ExampleUITests-acknowledgements.plist"; sourceTree = "<group>"; };
-		426DF59AC8B6E137F970AFE5C2D465CB /* SSD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSD.swift; path = CardScan/Classes/SSD.swift; sourceTree = "<group>"; };
-		4570767FFE01C4B25A50BBA081797100 /* DetectedAllBoxes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedAllBoxes.swift; path = CardScan/Classes/DetectedAllBoxes.swift; sourceTree = "<group>"; };
 		46DC03BD80E2956D4C1C6E7A463DF7CC /* Pods-CardScan_ExampleUITests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CardScan_ExampleUITests-dummy.m"; sourceTree = "<group>"; };
 		47D775EE4D1104200D8E8829E142AB6A /* Pods_CardScan_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CardScan_ExampleUITests.framework; path = "Pods-CardScan_ExampleUITests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A1EB432B71FA41CA2994D50A9F98B80 /* BlurView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlurView.swift; path = CardScan/Classes/BlurView.swift; sourceTree = "<group>"; };
-		4D036A1E9A7A7F9D1A389F7D8A6D5A7D /* FourRecognize.mlmodelc */ = {isa = PBXFileReference; includeInIndex = 1; name = FourRecognize.mlmodelc; path = CardScan/Assets/FourRecognize.mlmodelc; sourceTree = "<group>"; };
-		51631EC8B0986A93C716C12B361339FF /* ScanViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanViewController.swift; path = CardScan/Classes/ScanViewController.swift; sourceTree = "<group>"; };
-		51C59D78C14F1100B73AE0A33B8A160B /* FindFourOcr.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FindFourOcr.swift; path = CardScan/Classes/FindFourOcr.swift; sourceTree = "<group>"; };
-		5370D7A369E468500E0E6DD279AD98B8 /* CardScan-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CardScan-prefix.pch"; sourceTree = "<group>"; };
-		5585817995466462ABC6DFAA5A91F9F1 /* CardScan-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CardScan-Info.plist"; sourceTree = "<group>"; };
+		4A888BD11EA1A9C5FBF7B07001126C95 /* ResourceBundle-CardScan-CardScan-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-CardScan-CardScan-Info.plist"; sourceTree = "<group>"; };
+		4BDAF1773F173A18F825B02717BA3874 /* RecognizedDigits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecognizedDigits.swift; path = CardScan/Classes/RecognizedDigits.swift; sourceTree = "<group>"; };
+		52FB602441DAF392D060ADD3A4EF697B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		578A72E94737B49C6F188F0870E9736C /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = CardScan/Assets/Assets.xcassets; sourceTree = "<group>"; };
+		5906FA8937A733DAACECF1E53CE67F07 /* PredictionResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PredictionResult.swift; path = CardScan/Classes/PredictionResult.swift; sourceTree = "<group>"; };
+		59AD17BA3C2BA094EA1BB48FCE382E6B /* GeneratedModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GeneratedModels.swift; path = CardScan/Classes/GeneratedModels.swift; sourceTree = "<group>"; };
 		5E8C6DF275752BA22E147DDD056F2B63 /* Pods-CardScan_ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5F3D6232D66AB92C4E4EB2171181ACC0 /* SsdDetect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SsdDetect.swift; path = CardScan/Classes/SsdDetect.swift; sourceTree = "<group>"; };
+		60F73458DBB4783F9898E57E5498C38F /* ModelOutputExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ModelOutputExtensions.swift; path = CardScan/Classes/ModelOutputExtensions.swift; sourceTree = "<group>"; };
+		6124C0A0CECB72750894B5750C6C3FD4 /* Expiry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expiry.swift; path = CardScan/Classes/Expiry.swift; sourceTree = "<group>"; };
+		67A9E17DBD29A2EF763AAAADD5625A13 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppState.swift; path = CardScan/Classes/AppState.swift; sourceTree = "<group>"; };
+		68ED150C8A308E2D1A4DE7A46A4CB6CF /* VideoFeed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoFeed.swift; path = CardScan/Classes/VideoFeed.swift; sourceTree = "<group>"; };
 		6C75C6A60DC603E2981167EBE03791CC /* Pods-CardScan_ExampleTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_ExampleTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		6D9F9D023C7C021E47752FB45347CC0C /* PriorsGen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorsGen.swift; path = CardScan/Classes/PriorsGen.swift; sourceTree = "<group>"; };
+		6CBC09763865822F7D4585D0FB6A547D /* NMS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMS.swift; path = CardScan/Classes/NMS.swift; sourceTree = "<group>"; };
+		6CF4A40D168C62F876367EBB057D89CB /* CardScan-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "CardScan-dummy.m"; sourceTree = "<group>"; };
 		6E4A0C524729EC596EF748B192128499 /* Pods-CardScan_ExampleTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CardScan_ExampleTests-frameworks.sh"; sourceTree = "<group>"; };
 		6F22D99C9205E11A26243D541C2CF27C /* Pods-CardScan_ExampleUITests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-CardScan_ExampleUITests-frameworks.sh"; sourceTree = "<group>"; };
 		704FD45B9A3CEB394F814C7DA9401DB5 /* CardScan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = CardScan.framework; path = CardScan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7376E3957F2CEFE60CE359FAC4F9B229 /* CardScan.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = CardScan.storyboard; path = CardScan/Assets/CardScan.storyboard; sourceTree = "<group>"; };
 		741A6EE5ED2F172DC51CCEDE337923EA /* Pods-CardScan_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		7460CC649B352EBA9F687DAA8906CC87 /* Pods-CardScan_ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		778761861A24D24AC8F316E1ED85DEE1 /* ModelOutputExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ModelOutputExtensions.swift; path = CardScan/Classes/ModelOutputExtensions.swift; sourceTree = "<group>"; };
 		7DB27DFB297D7A7E0C2D251AB17C29F8 /* Pods-CardScan_ExampleUITests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CardScan_ExampleUITests.modulemap"; sourceTree = "<group>"; };
-		8297603D1A867225A4D0E5E67C8DFAFC /* GeneratedModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GeneratedModels.swift; path = CardScan/Classes/GeneratedModels.swift; sourceTree = "<group>"; };
-		852EE34AD1948C54333435F4BE005D6B /* CardScan.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = CardScan.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		87177E96923392E6353138A777915DD0 /* Pods-CardScan_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CardScan_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		8E21CB6B34F3B677B3F1848599FBF02A /* CreditCardUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreditCardUtils.swift; path = CardScan/Classes/CreditCardUtils.swift; sourceTree = "<group>"; };
-		95EDDC53D9A6B3AF16F61EA38C8C4D76 /* SSDOutputExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSDOutputExtensions.swift; path = CardScan/Classes/SSDOutputExtensions.swift; sourceTree = "<group>"; };
-		97DCE401FD6C43421CAD8A74FF8F6DC5 /* PreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreviewView.swift; path = CardScan/Classes/PreviewView.swift; sourceTree = "<group>"; };
-		988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CardScan.xcconfig; sourceTree = "<group>"; };
+		887792CBD80BBB0DC09A3C2CB2E27E11 /* FindFour.mlmodelc */ = {isa = PBXFileReference; includeInIndex = 1; name = FindFour.mlmodelc; path = CardScan/Assets/FindFour.mlmodelc; sourceTree = "<group>"; };
+		88C406009426C9BEE6DFE09E5F61095B /* CardScan.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = CardScan.modulemap; sourceTree = "<group>"; };
+		8D600AC6414E63E93C6B94B411F9802C /* CardScan-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "CardScan-Info.plist"; sourceTree = "<group>"; };
+		90BDAD85A2C5AEEAFDB355C9CE37B486 /* SSD.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSD.swift; path = CardScan/Classes/SSD.swift; sourceTree = "<group>"; };
+		92B530141DA2C85A30DF8D10662C4A2B /* CGRectExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CGRectExtension.swift; path = CardScan/Classes/CGRectExtension.swift; sourceTree = "<group>"; };
+		95E020D9739860F5BF1DCD9D4B32096B /* CornerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CornerView.swift; path = CardScan/Classes/CornerView.swift; sourceTree = "<group>"; };
 		9993926088E7489340DBB6602A45C25D /* Pods-CardScan_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CardScan_Example-umbrella.h"; sourceTree = "<group>"; };
-		9B2A85176CFC02B60DE8CDB48943D636 /* SsdDetect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SsdDetect.swift; path = CardScan/Classes/SsdDetect.swift; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A014265D7B8322076BC903FAB804C3CC /* Torch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Torch.swift; path = CardScan/Classes/Torch.swift; sourceTree = "<group>"; };
+		9E68A4ECE46F084543B54A63A45506E4 /* ScanConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanConfiguration.swift; path = CardScan/Classes/ScanConfiguration.swift; sourceTree = "<group>"; };
 		A0FE5B25D685D3AFCD363BB7416B228F /* Pods-CardScan_ExampleUITests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CardScan_ExampleUITests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A1308A9EE135E70590DD3E266C6CA700 /* Pods-CardScan_ExampleTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CardScan_ExampleTests-umbrella.h"; sourceTree = "<group>"; };
-		AC2EA18398EA0489B76BA2911A057C0C /* PredictionResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PredictionResult.swift; path = CardScan/Classes/PredictionResult.swift; sourceTree = "<group>"; };
-		AE7BEB361AFC8DD00A4F33695347C2CD /* UIImage+pixelBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIImage+pixelBuffer.swift"; path = "CardScan/Classes/UIImage+pixelBuffer.swift"; sourceTree = "<group>"; };
-		B0E651440496A1361460144ECBE7DA67 /* PostDetectionAlgorithm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostDetectionAlgorithm.swift; path = CardScan/Classes/PostDetectionAlgorithm.swift; sourceTree = "<group>"; };
-		B3AD27D38524BD53DCF1B446817D334E /* RecognizeNumbers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecognizeNumbers.swift; path = CardScan/Classes/RecognizeNumbers.swift; sourceTree = "<group>"; };
-		B673A58D315C7296856EAD8CBF45D67F /* NMS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMS.swift; path = CardScan/Classes/NMS.swift; sourceTree = "<group>"; };
-		B84B196E5F9DB0B72C7BE4CFB1A881CC /* BundleURL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BundleURL.swift; path = CardScan/Classes/BundleURL.swift; sourceTree = "<group>"; };
+		AAB46B8AC753853ABFD98E793D4D6552 /* ScanBaseViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanBaseViewController.swift; path = CardScan/Classes/ScanBaseViewController.swift; sourceTree = "<group>"; };
+		AC336A09602F971886DF7F70045BF398 /* CardScan-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CardScan-umbrella.h"; sourceTree = "<group>"; };
+		ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = CardScan.xcconfig; sourceTree = "<group>"; };
+		B3BF8EBC28AFA91ADF898B2E748A8526 /* FourRecognize.mlmodelc */ = {isa = PBXFileReference; includeInIndex = 1; name = FourRecognize.mlmodelc; path = CardScan/Assets/FourRecognize.mlmodelc; sourceTree = "<group>"; };
 		B864C20E0DD5D94BF86349F68B7D0F03 /* Pods-CardScan_ExampleTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-CardScan_ExampleTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B8C7248F43DB81343B1056F015483190 /* DetectedBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedBox.swift; path = CardScan/Classes/DetectedBox.swift; sourceTree = "<group>"; };
 		B99ED949FACB88F301300B0C22FD9618 /* Pods-CardScan_ExampleUITests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_ExampleUITests-Info.plist"; sourceTree = "<group>"; };
+		BABAC670D7994878BB8DA83B5648953A /* API.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = API.swift; path = CardScan/Classes/API.swift; sourceTree = "<group>"; };
 		BDE16F2D417E4B470FF336342C789E52 /* Pods-CardScan_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-CardScan_Example-dummy.m"; sourceTree = "<group>"; };
 		BE55EF84B81A2F97DECC25CF2E1A8311 /* Pods-CardScan_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_Example-Info.plist"; sourceTree = "<group>"; };
-		C1ED19890CA254D5B6A8093198DF9EA3 /* ScanStats.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanStats.swift; path = CardScan/Classes/ScanStats.swift; sourceTree = "<group>"; };
-		C3EEC78D590E0BCBFEB69A22F4964FB7 /* Ocr.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ocr.swift; path = CardScan/Classes/Ocr.swift; sourceTree = "<group>"; };
-		D074364BEED822E60E9BEE44CE78220E /* ScanEventsProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanEventsProtocol.swift; path = CardScan/Classes/ScanEventsProtocol.swift; sourceTree = "<group>"; };
-		D1025D0CB83E1F183E3E9D5772B9ED1E /* ScanBaseViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanBaseViewController.swift; path = CardScan/Classes/ScanBaseViewController.swift; sourceTree = "<group>"; };
-		D10F172B3DF60D2A29DD095A5BAFC816 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = CardScan/Assets/Assets.xcassets; sourceTree = "<group>"; };
+		C66E6591F15807AFEAD91F80C1327604 /* BundleURL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BundleURL.swift; path = CardScan/Classes/BundleURL.swift; sourceTree = "<group>"; };
+		C98ED6E9C83923BC90124C910E6C5412 /* ScanEventsProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanEventsProtocol.swift; path = CardScan/Classes/ScanEventsProtocol.swift; sourceTree = "<group>"; };
+		CC5A43AB65D96563B851B8B1CDE6549F /* PredictionAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PredictionAPI.swift; path = CardScan/Classes/PredictionAPI.swift; sourceTree = "<group>"; };
+		D4FC561FE4C073D7A7324761474D973C /* Ocr.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ocr.swift; path = CardScan/Classes/Ocr.swift; sourceTree = "<group>"; };
+		D4FCEB0408CF28FB08DC5FF27181C50B /* PriorsGen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorsGen.swift; path = CardScan/Classes/PriorsGen.swift; sourceTree = "<group>"; };
+		D54239E7FF05E3E70C4CF43F4E1AFDB0 /* FindFourOcr.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FindFourOcr.swift; path = CardScan/Classes/FindFourOcr.swift; sourceTree = "<group>"; };
 		D87B5E76D06D58DAAE6F6A81B2E8C91F /* Pods-CardScan_ExampleUITests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-CardScan_ExampleUITests-umbrella.h"; sourceTree = "<group>"; };
-		D92DC7D1FC427323456D34C84421AAF4 /* CornerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CornerView.swift; path = CardScan/Classes/CornerView.swift; sourceTree = "<group>"; };
-		DF8FBA3D14B4A50D12DDFF5B16338122 /* FindFour.mlmodelc */ = {isa = PBXFileReference; includeInIndex = 1; name = FindFour.mlmodelc; path = CardScan/Assets/FindFour.mlmodelc; sourceTree = "<group>"; };
-		E0C0695EB349D3989F608CD8B8C5483E /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppState.swift; path = CardScan/Classes/AppState.swift; sourceTree = "<group>"; };
-		E16688A44D245E396D7598891A32C391 /* DetectedBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetectedBox.swift; path = CardScan/Classes/DetectedBox.swift; sourceTree = "<group>"; };
-		E180F58C5B06E52B3F6239EE57945158 /* Expiry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expiry.swift; path = CardScan/Classes/Expiry.swift; sourceTree = "<group>"; };
+		D8D466BEB23E59F4E3366F48F7A22589 /* CardScan-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CardScan-prefix.pch"; sourceTree = "<group>"; };
+		DEED44B35BCD836F3DA11C90A6CE22F5 /* PostDetectionAlgorithm.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostDetectionAlgorithm.swift; path = CardScan/Classes/PostDetectionAlgorithm.swift; sourceTree = "<group>"; };
 		E1B80E759A6961B2A6CEF81597FA601E /* Pods-CardScan_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-CardScan_Example.modulemap"; sourceTree = "<group>"; };
-		E1BAA8E73C0D9D7D2E0BF820D635A888 /* PredictionAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PredictionAPI.swift; path = CardScan/Classes/PredictionAPI.swift; sourceTree = "<group>"; };
-		E5D249E7978AAF0F5D8D371A18536C92 /* RecognizedDigits.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecognizedDigits.swift; path = CardScan/Classes/RecognizedDigits.swift; sourceTree = "<group>"; };
+		EB3E9A0A1EB35A028C9E2CFCFCF83DCE /* BlurView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlurView.swift; path = CardScan/Classes/BlurView.swift; sourceTree = "<group>"; };
+		ED59CA8606A8D743208CAB1BA734E6C4 /* CardScan.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = CardScan.storyboard; path = CardScan/Assets/CardScan.storyboard; sourceTree = "<group>"; };
 		EDF0E5B99E89D61CB52287BEAD563AA4 /* Pods-CardScan_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_Example.release.xcconfig"; sourceTree = "<group>"; };
+		F091605D8CEA6BF6BA04CD1BF87EA55A /* PreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreviewView.swift; path = CardScan/Classes/PreviewView.swift; sourceTree = "<group>"; };
 		F24B32594CCE53E699907ABD6A6A0440 /* Pods-CardScan_ExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-CardScan_ExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
-		F2F4CA541F8C06D66D9FB925C2140690 /* VideoFeed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoFeed.swift; path = CardScan/Classes/VideoFeed.swift; sourceTree = "<group>"; };
 		F396163755D56F466F82263D8E177356 /* Pods_CardScan_ExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_CardScan_ExampleTests.framework; path = "Pods-CardScan_ExampleTests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7CA4BD6EA844A98E3ECBF431189A0EB /* Pods-CardScan_ExampleTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-CardScan_ExampleTests-Info.plist"; sourceTree = "<group>"; };
+		F98D49B2E75DE652E23A3AA29A12D0A9 /* RecognizeNumbers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecognizeNumbers.swift; path = CardScan/Classes/RecognizeNumbers.swift; sourceTree = "<group>"; };
+		FEDFDDFA8AE391401D49102D8FD66FA4 /* SSDOutputExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SSDOutputExtensions.swift; path = CardScan/Classes/SSDOutputExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0DA77049957759F1F47BAF4898BF416D /* Frameworks */ = {
+		479CB9D99CCE0E767E268ABFC57AD2A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9F2C8F4981831E154161D121B564DFF /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		2E2529D7A8C1ADA7A4B4EC99E8D2C163 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				ED5CF31B07949FF539FAFAD14B38F8D9 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +223,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CC9A03228F01DFC54158DF8697F55143 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -241,81 +243,82 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		1A80E41692EED4CC5FF34613525D6AA7 /* Resources */ = {
+		0C10753097B41916F7E4952D33AD052C /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				D10F172B3DF60D2A29DD095A5BAFC816 /* Assets.xcassets */,
-				7376E3957F2CEFE60CE359FAC4F9B229 /* CardScan.storyboard */,
-				DF8FBA3D14B4A50D12DDFF5B16338122 /* FindFour.mlmodelc */,
-				4D036A1E9A7A7F9D1A389F7D8A6D5A7D /* FourRecognize.mlmodelc */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		6EAD691289D859136899F8D4E51B99C4 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				359C199804560EA9E70C8AB847B39CBA /* API.swift */,
-				E0C0695EB349D3989F608CD8B8C5483E /* AppState.swift */,
-				4A1EB432B71FA41CA2994D50A9F98B80 /* BlurView.swift */,
-				B84B196E5F9DB0B72C7BE4CFB1A881CC /* BundleURL.swift */,
-				2E2BB1B31106DB442D30CB2BB35A84E6 /* CGRectExtension.swift */,
-				D92DC7D1FC427323456D34C84421AAF4 /* CornerView.swift */,
-				8E21CB6B34F3B677B3F1848599FBF02A /* CreditCardUtils.swift */,
-				4570767FFE01C4B25A50BBA081797100 /* DetectedAllBoxes.swift */,
-				E16688A44D245E396D7598891A32C391 /* DetectedBox.swift */,
-				37370DDF3E1AEA518EBF3E1D9F3DB901 /* DetectedSSDBox.swift */,
-				E180F58C5B06E52B3F6239EE57945158 /* Expiry.swift */,
-				51C59D78C14F1100B73AE0A33B8A160B /* FindFourOcr.swift */,
-				8297603D1A867225A4D0E5E67C8DFAFC /* GeneratedModels.swift */,
-				778761861A24D24AC8F316E1ED85DEE1 /* ModelOutputExtensions.swift */,
-				B673A58D315C7296856EAD8CBF45D67F /* NMS.swift */,
-				C3EEC78D590E0BCBFEB69A22F4964FB7 /* Ocr.swift */,
-				B0E651440496A1361460144ECBE7DA67 /* PostDetectionAlgorithm.swift */,
-				E1BAA8E73C0D9D7D2E0BF820D635A888 /* PredictionAPI.swift */,
-				AC2EA18398EA0489B76BA2911A057C0C /* PredictionResult.swift */,
-				97DCE401FD6C43421CAD8A74FF8F6DC5 /* PreviewView.swift */,
-				6D9F9D023C7C021E47752FB45347CC0C /* PriorsGen.swift */,
-				E5D249E7978AAF0F5D8D371A18536C92 /* RecognizedDigits.swift */,
-				B3AD27D38524BD53DCF1B446817D334E /* RecognizeNumbers.swift */,
-				D1025D0CB83E1F183E3E9D5772B9ED1E /* ScanBaseViewController.swift */,
-				D074364BEED822E60E9BEE44CE78220E /* ScanEventsProtocol.swift */,
-				C1ED19890CA254D5B6A8093198DF9EA3 /* ScanStats.swift */,
-				51631EC8B0986A93C716C12B361339FF /* ScanViewController.swift */,
-				426DF59AC8B6E137F970AFE5C2D465CB /* SSD.swift */,
-				9B2A85176CFC02B60DE8CDB48943D636 /* SsdDetect.swift */,
-				95EDDC53D9A6B3AF16F61EA38C8C4D76 /* SSDOutputExtensions.swift */,
-				A014265D7B8322076BC903FAB804C3CC /* Torch.swift */,
-				AE7BEB361AFC8DD00A4F33695347C2CD /* UIImage+pixelBuffer.swift */,
-				F2F4CA541F8C06D66D9FB925C2140690 /* VideoFeed.swift */,
-				1A80E41692EED4CC5FF34613525D6AA7 /* Resources */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		81A90AC8EEE6FFB6ECAE820E0C6F1FB9 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				148D2749B687D5C3320ED415CE470909 /* CardScan.modulemap */,
-				988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */,
-				34CA68A62F11D5A796569EF92C1567AC /* CardScan-dummy.m */,
-				5585817995466462ABC6DFAA5A91F9F1 /* CardScan-Info.plist */,
-				5370D7A369E468500E0E6DD279AD98B8 /* CardScan-prefix.pch */,
-				1BC553DD501F0542789355885B135BE5 /* CardScan-umbrella.h */,
-				32B070D806DE6A2CE8251F2C9D12FE3A /* ResourceBundle-CardScan-CardScan-Info.plist */,
+				88C406009426C9BEE6DFE09E5F61095B /* CardScan.modulemap */,
+				ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */,
+				6CF4A40D168C62F876367EBB057D89CB /* CardScan-dummy.m */,
+				8D600AC6414E63E93C6B94B411F9802C /* CardScan-Info.plist */,
+				D8D466BEB23E59F4E3366F48F7A22589 /* CardScan-prefix.pch */,
+				AC336A09602F971886DF7F70045BF398 /* CardScan-umbrella.h */,
+				4A888BD11EA1A9C5FBF7B07001126C95 /* ResourceBundle-CardScan-CardScan-Info.plist */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/CardScan";
 			sourceTree = "<group>";
 		};
-		8F106B2A371310E02ED0C2A1DC4D177E /* Pod */ = {
+		143342B88713B982BAB7A6D47DBFFAEB /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				852EE34AD1948C54333435F4BE005D6B /* CardScan.podspec */,
-				37D29DF722D4E03AF8AAE5F5D3E260ED /* LICENSE */,
-				0D37C1388C6F78AFFF5406894BA7F7CF /* README.md */,
+				349723ABCDE7F7BA7308A774A2748940 /* CardScan.podspec */,
+				3135605ECEFA0B90989935FDC39C1C4C /* LICENSE */,
+				52FB602441DAF392D060ADD3A4EF697B /* README.md */,
 			);
 			name = Pod;
+			sourceTree = "<group>";
+		};
+		52DFB7707AF5B20BA3DF0C520F53AB91 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				BABAC670D7994878BB8DA83B5648953A /* API.swift */,
+				67A9E17DBD29A2EF763AAAADD5625A13 /* AppState.swift */,
+				EB3E9A0A1EB35A028C9E2CFCFCF83DCE /* BlurView.swift */,
+				C66E6591F15807AFEAD91F80C1327604 /* BundleURL.swift */,
+				92B530141DA2C85A30DF8D10662C4A2B /* CGRectExtension.swift */,
+				95E020D9739860F5BF1DCD9D4B32096B /* CornerView.swift */,
+				34B915CC18296B2F72989CB0FA8939D3 /* CreditCardUtils.swift */,
+				0C50F653EFB21A2E9525ADF1CCC5985A /* DetectedAllBoxes.swift */,
+				B8C7248F43DB81343B1056F015483190 /* DetectedBox.swift */,
+				10A692EEAA502D49968CC9666A5119D1 /* DetectedSSDBox.swift */,
+				6124C0A0CECB72750894B5750C6C3FD4 /* Expiry.swift */,
+				D54239E7FF05E3E70C4CF43F4E1AFDB0 /* FindFourOcr.swift */,
+				59AD17BA3C2BA094EA1BB48FCE382E6B /* GeneratedModels.swift */,
+				60F73458DBB4783F9898E57E5498C38F /* ModelOutputExtensions.swift */,
+				6CBC09763865822F7D4585D0FB6A547D /* NMS.swift */,
+				D4FC561FE4C073D7A7324761474D973C /* Ocr.swift */,
+				DEED44B35BCD836F3DA11C90A6CE22F5 /* PostDetectionAlgorithm.swift */,
+				CC5A43AB65D96563B851B8B1CDE6549F /* PredictionAPI.swift */,
+				5906FA8937A733DAACECF1E53CE67F07 /* PredictionResult.swift */,
+				F091605D8CEA6BF6BA04CD1BF87EA55A /* PreviewView.swift */,
+				D4FCEB0408CF28FB08DC5FF27181C50B /* PriorsGen.swift */,
+				4BDAF1773F173A18F825B02717BA3874 /* RecognizedDigits.swift */,
+				F98D49B2E75DE652E23A3AA29A12D0A9 /* RecognizeNumbers.swift */,
+				AAB46B8AC753853ABFD98E793D4D6552 /* ScanBaseViewController.swift */,
+				9E68A4ECE46F084543B54A63A45506E4 /* ScanConfiguration.swift */,
+				C98ED6E9C83923BC90124C910E6C5412 /* ScanEventsProtocol.swift */,
+				3DE64E0559DEC4346F06AD6E8E50AAB7 /* ScanStats.swift */,
+				3EE961F44D5CEA3DA5F25DDDFF4E7955 /* ScanViewController.swift */,
+				90BDAD85A2C5AEEAFDB355C9CE37B486 /* SSD.swift */,
+				5F3D6232D66AB92C4E4EB2171181ACC0 /* SsdDetect.swift */,
+				FEDFDDFA8AE391401D49102D8FD66FA4 /* SSDOutputExtensions.swift */,
+				2A9832415F4370CFC8C705B134EF5473 /* Torch.swift */,
+				1C7CE6D5BE3ECA171502B7F367D430B3 /* UIImage+pixelBuffer.swift */,
+				68ED150C8A308E2D1A4DE7A46A4CB6CF /* VideoFeed.swift */,
+				533D75847CC47B9795CDFAAB415DF604 /* Resources */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		533D75847CC47B9795CDFAAB415DF604 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				578A72E94737B49C6F188F0870E9736C /* Assets.xcassets */,
+				ED59CA8606A8D743208CAB1BA734E6C4 /* CardScan.storyboard */,
+				887792CBD80BBB0DC09A3C2CB2E27E11 /* FindFour.mlmodelc */,
+				B3BF8EBC28AFA91ADF898B2E748A8526 /* FourRecognize.mlmodelc */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 		92DD9648E8EE7A853335F8C4D45C50FF /* Pods-CardScan_ExampleUITests */ = {
@@ -350,17 +353,17 @@
 		A48BE968D38DD11741E7540B51579F50 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B174B0101799FDCF05701A73ED49F0F6 /* CardScan */,
+				C00FCC56F70DDEAD8DC0FAFC8451B34F /* CardScan */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		B174B0101799FDCF05701A73ED49F0F6 /* CardScan */ = {
+		C00FCC56F70DDEAD8DC0FAFC8451B34F /* CardScan */ = {
 			isa = PBXGroup;
 			children = (
-				6EAD691289D859136899F8D4E51B99C4 /* Core */,
-				8F106B2A371310E02ED0C2A1DC4D177E /* Pod */,
-				81A90AC8EEE6FFB6ECAE820E0C6F1FB9 /* Support Files */,
+				52DFB7707AF5B20BA3DF0C520F53AB91 /* Core */,
+				143342B88713B982BAB7A6D47DBFFAEB /* Pod */,
+				0C10753097B41916F7E4952D33AD052C /* Support Files */,
 			);
 			name = CardScan;
 			path = ../..;
@@ -438,11 +441,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2184497717BD48AC01F2DB69257B05B9 /* Headers */ = {
+		1CB66D3A4858771B616F83AB6C1D091D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D9A20D606D607EB5D509F02E19FB8B2C /* CardScan-umbrella.h in Headers */,
+				9149C69E5E95131E546C79E739456ADA /* CardScan-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,17 +490,17 @@
 		};
 		7A35B702D709EA37681B6545A4E1EF1B /* CardScan */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0C2392C4FE9C0AF7302F53E714A12F7D /* Build configuration list for PBXNativeTarget "CardScan" */;
+			buildConfigurationList = 635960F9A6E0F17BD2BF581594601389 /* Build configuration list for PBXNativeTarget "CardScan" */;
 			buildPhases = (
-				2184497717BD48AC01F2DB69257B05B9 /* Headers */,
-				56AC3D48C4D1F239BE9BAE17857C01A2 /* Sources */,
-				0DA77049957759F1F47BAF4898BF416D /* Frameworks */,
-				B0A0DE9684D13319853E22E0CB3D636D /* Resources */,
+				1CB66D3A4858771B616F83AB6C1D091D /* Headers */,
+				0835C21762A8304BE96A2CA0F7AD1F41 /* Sources */,
+				479CB9D99CCE0E767E268ABFC57AD2A9 /* Frameworks */,
+				64F172B8F5BBDD8801A3CE6955FAC750 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				CEAA0A94B3FCC93CCD9D75A4B7716DF6 /* PBXTargetDependency */,
+				A626257AB50858D59277E4F77132023C /* PBXTargetDependency */,
 			);
 			name = CardScan;
 			productName = CardScan;
@@ -545,11 +548,11 @@
 		};
 		E28C2932ED4A11BBB17E34185D144C4E /* CardScan-CardScan */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 30B38256B59FCCD072AEF5F7868D0D07 /* Build configuration list for PBXNativeTarget "CardScan-CardScan" */;
+			buildConfigurationList = A7B783B949E6FD9E0EFF42E90C452A2F /* Build configuration list for PBXNativeTarget "CardScan-CardScan" */;
 			buildPhases = (
-				1FC26E70FBA5B00D904271626C2EDA19 /* Sources */,
-				2E2529D7A8C1ADA7A4B4EC99E8D2C163 /* Frameworks */,
-				747EE585F7C917E46A234AA0E53E08DB /* Resources */,
+				CD014339ADFF5427976F2C8E4A5BE0EF /* Sources */,
+				CC9A03228F01DFC54158DF8697F55143 /* Frameworks */,
+				771FC421362327F4CF7C10FED6CBC08D /* Resources */,
 			);
 			buildRules = (
 			);
@@ -605,22 +608,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		747EE585F7C917E46A234AA0E53E08DB /* Resources */ = {
+		64F172B8F5BBDD8801A3CE6955FAC750 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED5CCA52DCA821F5CAE7E2B241AFF7F2 /* Assets.xcassets in Resources */,
-				10D63F8AC26E8BE3A9A22AF390B9063F /* CardScan.storyboard in Resources */,
-				E7542E353AF5FD0FEF86A05EA5D481EB /* FindFour.mlmodelc in Resources */,
-				E4E6D4AE308D12AD740152A08922E515 /* FourRecognize.mlmodelc in Resources */,
+				3B6DDBCAF12F988DDB12406CB3106BEE /* CardScan.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B0A0DE9684D13319853E22E0CB3D636D /* Resources */ = {
+		771FC421362327F4CF7C10FED6CBC08D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EC2D2754FBA3601D3AE8BCD856F0CE66 /* CardScan.bundle in Resources */,
+				75575406017868093FCA48B37BB75E83 /* Assets.xcassets in Resources */,
+				674AB131358CF84C1DC70B11F5085F2C /* CardScan.storyboard in Resources */,
+				42643B39F1A8ABD5D20B9DFC50CB95C0 /* FindFour.mlmodelc in Resources */,
+				466B3EE8E2559D7F24C34AEAEDE031AF /* FourRecognize.mlmodelc in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -634,18 +637,53 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0835C21762A8304BE96A2CA0F7AD1F41 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				867A71A7FF8DD359879EC0EC991F0BF6 /* API.swift in Sources */,
+				D7CF5E7D127F5169AF905523659887CE /* AppState.swift in Sources */,
+				A216113297134E9A1695C4025E491658 /* BlurView.swift in Sources */,
+				3E75BE70CBFB676FDBABFCB407D2DA8E /* BundleURL.swift in Sources */,
+				C178655A30B5B8DA5467BF41740C6B0C /* CardScan-dummy.m in Sources */,
+				0632DEE15D8B4034206057F88279D1C3 /* CGRectExtension.swift in Sources */,
+				D51787DB928BC969983094EA883B9E7A /* CornerView.swift in Sources */,
+				1D7D1BD392873828D7FEA28BC5412DFA /* CreditCardUtils.swift in Sources */,
+				156DA25F5D7967D1E71BCC3C92BD5B78 /* DetectedAllBoxes.swift in Sources */,
+				CCC46F8CAF581D49148E1B45C545A167 /* DetectedBox.swift in Sources */,
+				F76320288A5BED28183B3C3CADA64A52 /* DetectedSSDBox.swift in Sources */,
+				B96FEC3CAEDF4CF7ECDE5EC2D5DB26BC /* Expiry.swift in Sources */,
+				2C5814DE9AE7ACA3B5784DD92E24D653 /* FindFourOcr.swift in Sources */,
+				3066FCBB356946D14BABDB26C0B51DBD /* GeneratedModels.swift in Sources */,
+				AC1126697B99FCA56337262DC0090AB4 /* ModelOutputExtensions.swift in Sources */,
+				F61938497B613355D66C9BB62B878DBC /* NMS.swift in Sources */,
+				E990D6FDB01D95286A76060EABF3EBD3 /* Ocr.swift in Sources */,
+				427DD17659DC11EA007E616DD43A9072 /* PostDetectionAlgorithm.swift in Sources */,
+				5B1F49452BD0CBEF2015FFB4E5385CAC /* PredictionAPI.swift in Sources */,
+				54A6E32A688D0E8B03E6E7ADF4E6AD74 /* PredictionResult.swift in Sources */,
+				61F1859D0E9614BEF9A2500B34651585 /* PreviewView.swift in Sources */,
+				519A0BA0EEC2ABC21AAC2CA2851FA356 /* PriorsGen.swift in Sources */,
+				6D567BA9C1C1709F11D10D0C3E785E70 /* RecognizedDigits.swift in Sources */,
+				C82AC5582BBD95345B7B4A4DBFA0B2CB /* RecognizeNumbers.swift in Sources */,
+				E9A13EAD83ECC08F1D80A1C61DEEE93D /* ScanBaseViewController.swift in Sources */,
+				94C4F51292B9ECD71F3D674FC6869613 /* ScanConfiguration.swift in Sources */,
+				140DCE84C2C667121DC0219FF1CD61AB /* ScanEventsProtocol.swift in Sources */,
+				9D132ED1DEAAA32B72782EEA2D33E97F /* ScanStats.swift in Sources */,
+				2FA7E7D67CC79C8F728FEA1327E79B5F /* ScanViewController.swift in Sources */,
+				9AAFE69055E225D742EC96352BF7AB07 /* SSD.swift in Sources */,
+				DF47973DEF83664C4C09D7B46B35565E /* SsdDetect.swift in Sources */,
+				CAB9A81382969CCD005AF9905295F0AD /* SSDOutputExtensions.swift in Sources */,
+				62B4493A60BA797583313328E288301F /* Torch.swift in Sources */,
+				99A89BE96894506FBBA3AE124060A993 /* UIImage+pixelBuffer.swift in Sources */,
+				F429DD4A64E1BEBCD728F2F7F000D54D /* VideoFeed.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1BBBCDDBE4159B7E5272A2D9CFD6CA8D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				DBF656F52831440886C7B96A12349C04 /* Pods-CardScan_ExampleUITests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1FC26E70FBA5B00D904271626C2EDA19 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -657,52 +695,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		56AC3D48C4D1F239BE9BAE17857C01A2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3ED9794A37A2856D05C8BE8966BCF2C0 /* API.swift in Sources */,
-				523B667BF8D1201E25DB2E3BE5707E7D /* AppState.swift in Sources */,
-				2A3C77561D64D25E0B4317FB958E72F2 /* BlurView.swift in Sources */,
-				094DF50A927EC0DC71DF3CB86085B0D4 /* BundleURL.swift in Sources */,
-				3F9153A9EA6478CA822A1E8F16C307C3 /* CardScan-dummy.m in Sources */,
-				FDE914C56D3772280415410B455D6F5F /* CGRectExtension.swift in Sources */,
-				273DAC21E24A247ED89A744C46E6B67E /* CornerView.swift in Sources */,
-				29B307C195B81B7E588547BF12B92D0E /* CreditCardUtils.swift in Sources */,
-				F14EF4502A88E6A7B9E8DA1FD4E64F65 /* DetectedAllBoxes.swift in Sources */,
-				9422AEA1EAEBBAACC800BC8D1FED8729 /* DetectedBox.swift in Sources */,
-				3428161F561705938A8B745F2F08513E /* DetectedSSDBox.swift in Sources */,
-				4F3E897A6FE1F22DCBB77F29503DC3C8 /* Expiry.swift in Sources */,
-				94AD0AC63B0B33132CBE1CEDF98888EF /* FindFourOcr.swift in Sources */,
-				DE8FC4964FDE2EEE89193F6CDD8E4B3A /* GeneratedModels.swift in Sources */,
-				32E4A4C5CA51CF8780FD8A2173FF430E /* ModelOutputExtensions.swift in Sources */,
-				5389BA3233573DA74A777D4473EC1B87 /* NMS.swift in Sources */,
-				371CFA1A3F67E9CE1D77F2B24E0B070C /* Ocr.swift in Sources */,
-				6020EF2D7D359B7B5167D4571D9ADC19 /* PostDetectionAlgorithm.swift in Sources */,
-				0BCBFF0C01DDA1902A4E9029A7DCFB64 /* PredictionAPI.swift in Sources */,
-				A7C9CBCD07A729285CB6B70854E13107 /* PredictionResult.swift in Sources */,
-				37122C6A9ABF64FBDA30002A1890EFC2 /* PreviewView.swift in Sources */,
-				9FABCD1C6DD1A2CA46D70F0EB8987346 /* PriorsGen.swift in Sources */,
-				A22C95B1B98DF3525C6DEE6350BA6263 /* RecognizedDigits.swift in Sources */,
-				D331EC69905DF1BACD7806F55858FDD0 /* RecognizeNumbers.swift in Sources */,
-				C536C3BBBCD807F15133FD4BA166C5F4 /* ScanBaseViewController.swift in Sources */,
-				6EC374D0FAA6302B5E41F4517BB4F481 /* ScanEventsProtocol.swift in Sources */,
-				60AD08C910BA9EF8DC12D7AE45E6C7F4 /* ScanStats.swift in Sources */,
-				D9ACA84A95D668695B10E1FE2419691B /* ScanViewController.swift in Sources */,
-				3C58DA8B2FC4AA88A4C112B8CDCBE27B /* SSD.swift in Sources */,
-				9B6018F4D0EB4763F979C71288B2FF96 /* SsdDetect.swift in Sources */,
-				C6A2913DDA5E0AE85222AE972238A36B /* SSDOutputExtensions.swift in Sources */,
-				C01A92989D46AE943EE14B8EB7453F9A /* Torch.swift in Sources */,
-				AF5985F346BFF4E6AAADA9CA36F9BD11 /* UIImage+pixelBuffer.swift in Sources */,
-				9AB912989633FC9A03F22FA0D5828F1F /* VideoFeed.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		89599FCDDC29E5E75665AC5977CB3BFE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				798E430EEC70011966BBFD257DC2FBD4 /* Pods-CardScan_ExampleTests-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD014339ADFF5427976F2C8E4A5BE0EF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -739,11 +743,11 @@
 			target = 7A35B702D709EA37681B6545A4E1EF1B /* CardScan */;
 			targetProxy = 71ABF33962AE7DC339FB60D9C9A51C7C /* PBXContainerItemProxy */;
 		};
-		CEAA0A94B3FCC93CCD9D75A4B7716DF6 /* PBXTargetDependency */ = {
+		A626257AB50858D59277E4F77132023C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "CardScan-CardScan";
 			target = E28C2932ED4A11BBB17E34185D144C4E /* CardScan-CardScan */;
-			targetProxy = 7F94C9A6DF7DCB1E36354718FE71062F /* PBXContainerItemProxy */;
+			targetProxy = 667AF9ECE991055C591FB61297A3D541 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -781,6 +785,22 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		0EB320D556A36ADAC06CE97D2E335915 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CardScan";
+				INFOPLIST_FILE = "Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_NAME = CardScan;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
 		};
 		196DFA3E4A09A28224918543529A1885 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -880,38 +900,6 @@
 			};
 			name = Debug;
 		};
-		502D2CE930C591221DA9D2781DBDF80A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/CardScan/CardScan-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/CardScan/CardScan-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/CardScan/CardScan.modulemap";
-				PRODUCT_MODULE_NAME = CardScan;
-				PRODUCT_NAME = CardScan;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		523A82A44BF7A045D25E12995D87D7D4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EDF0E5B99E89D61CB52287BEAD563AA4 /* Pods-CardScan_Example.release.xcconfig */;
@@ -982,19 +970,35 @@
 			};
 			name = Release;
 		};
-		6C1E8C9C4DA39B9517994885758A9AD3 /* Debug */ = {
+		6D86CF4D47D109FC559115729FE21B10 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */;
+			baseConfigurationReference = ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CardScan";
-				INFOPLIST_FILE = "Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/CardScan/CardScan-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/CardScan/CardScan-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/CardScan/CardScan.modulemap";
+				PRODUCT_MODULE_NAME = CardScan;
 				PRODUCT_NAME = CardScan;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -1092,6 +1096,22 @@
 			};
 			name = Release;
 		};
+		B11B6B8ACD5D8A45A813B60EF89C327B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CardScan";
+				INFOPLIST_FILE = "Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_NAME = CardScan;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
 		C16D7079C05B44CEA74290A4B92D5057 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7460CC649B352EBA9F687DAA8906CC87 /* Pods-CardScan_ExampleTests.release.xcconfig */;
@@ -1127,9 +1147,9 @@
 			};
 			name = Release;
 		};
-		C7DFDFE6EE9ED634DBC96CC828814125 /* Release */ = {
+		EF3E126FA1A9F252C7161343CF7B1B4B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */;
+			baseConfigurationReference = ACF52ECAA1C587A3FA1AD9F2F4D5BBB8 /* CardScan.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_IDENTITY = "";
@@ -1160,48 +1180,14 @@
 			};
 			name = Release;
 		};
-		CDB401879ACBB75D52C43740E2F76722 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 988C0D06064A2B7EE9FC701DC83A5CFC /* CardScan.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/CardScan";
-				INFOPLIST_FILE = "Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = CardScan;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0C2392C4FE9C0AF7302F53E714A12F7D /* Build configuration list for PBXNativeTarget "CardScan" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				502D2CE930C591221DA9D2781DBDF80A /* Debug */,
-				C7DFDFE6EE9ED634DBC96CC828814125 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		159CDE84C69A96C578EBDA44D333E35E /* Build configuration list for PBXNativeTarget "Pods-CardScan_ExampleTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				08FF1AEC092B8C1A52ED7ED3096531CF /* Debug */,
 				C16D7079C05B44CEA74290A4B92D5057 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		30B38256B59FCCD072AEF5F7868D0D07 /* Build configuration list for PBXNativeTarget "CardScan-CardScan" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				6C1E8C9C4DA39B9517994885758A9AD3 /* Debug */,
-				CDB401879ACBB75D52C43740E2F76722 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1215,11 +1201,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		635960F9A6E0F17BD2BF581594601389 /* Build configuration list for PBXNativeTarget "CardScan" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D86CF4D47D109FC559115729FE21B10 /* Debug */,
+				EF3E126FA1A9F252C7161343CF7B1B4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6F56F82CE5340D717CB1BF7438E1FAA9 /* Build configuration list for PBXNativeTarget "Pods-CardScan_ExampleUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1B5910A349E3341DC07A2313FC12BA4D /* Debug */,
 				5B7C4D2A5A70AF057A1E66FC229E7AA1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A7B783B949E6FD9E0EFF42E90C452A2F /* Build configuration list for PBXNativeTarget "CardScan-CardScan" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B11B6B8ACD5D8A45A813B60EF89C327B /* Debug */,
+				0EB320D556A36ADAC06CE97D2E335915 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Allows apps to run the model on older devices, which are disabled by default. We will change the devices we support by default as our models evolve, but using this will ensure that the model runs on all devices with a new enough OS version.