### PR TITLE
Deny experience

### DIFF
--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -248,8 +248,10 @@ import UIKit
     }
     
     override public func onCameraPermissionDenied(showedPrompt: Bool) {
-        if showedPrompt {
+        if !showedPrompt {
             self.showDenyAlert()
+        } else {
+            self.backButtonPress("")
         }
     }
     

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -122,7 +122,6 @@ import UIKit
     var denyPermissionMessage = "Please enable camera access in your settings to scan your card"
     
     var calledDelegate = false
-    var needToShowDenyAlert = false
     
     @objc static public func createViewController(withDelegate delegate: ScanDelegate? = nil) -> ScanViewController? {
         // use default config
@@ -268,11 +267,6 @@ import UIKit
             self.skipButton.isHidden = true
         }
         
-        let authorizationStatus = AVCaptureDevice.authorizationStatus(for: .video)
-        if authorizationStatus != .authorized && authorizationStatus != .notDetermined {
-            self.needToShowDenyAlert = true
-        }
-        
         let debugImageView = self.showDebugImageView ? self.debugImageView : nil
         self.setupOnViewDidLoad(regionOfInterestLabel: self.regionOfInterestLabel, blurView: self.blurView, previewView: self.previewView, cornerView: self.cornerView, debugImageView: debugImageView)
         self.startCameraPreview()
@@ -281,10 +275,6 @@ import UIKit
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         self.cornerView.layer.borderColor = self.cornerBorderColor
-        if self.needToShowDenyAlert {
-            self.needToShowDenyAlert = false
-            self.showDenyAlert()
-        }
     }
     
     public override func viewDidLayoutSubviews() {

--- a/Example/Pods/Target Support Files/CardScan/CardScan-Info.plist
+++ b/Example/Pods/Target Support Files/CardScan/CardScan-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.5011</string>
+  <string>1.0.5014</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Pods/Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist
+++ b/Example/Pods/Target Support Files/CardScan/ResourceBundle-CardScan-CardScan-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.5011</string>
+  <string>1.0.5014</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
Updates the deny experience logic because now that we moved session starting to after permissions our callbacks get invoked every time instead of getting invoked automatically by virtue of starting a capture session.