### PR TITLE
Moves setting the sessionPreset after addInput. 

### DIFF
--- a/CardScan/Classes/VideoFeed.swift
+++ b/CardScan/Classes/VideoFeed.swift
@@ -61,11 +61,7 @@ class VideoFeed {
         
         session.beginConfiguration()
         
-        if session.canSetSessionPreset(.iFrame960x540) {
-            session.sessionPreset = .iFrame960x540
-        }
-        
-        do {
+         do {
             var defaultVideoDevice: AVCaptureDevice?
             
             // Choose the back dual camera if available, otherwise default to a wide angle camera.
@@ -127,6 +123,10 @@ class VideoFeed {
                 return
             }
             session.addOutput(videoDeviceOutput)
+            
+            if session.canSetSessionPreset(.iFrame960x540) {
+                 session.sessionPreset = .iFrame960x540
+             }
             
             let connection = videoDeviceOutput.connection(with: .video)
             if connection?.isVideoOrientationSupported ?? false {


### PR DESCRIPTION
Fixes EXC_BAD_ACCESS that occurs after opening the camera 3+ times before attempting a scan. This is described in: https://github.com/getbouncer/cardscan-ios/issues/89.

Moving the line of code that sets the sessionPreset so that it is after addInput fixes the crash. I found this by comparing the CardScan code to Apple's sample code (https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/setting_up_a_capture_session) and (https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/avcam_building_a_camera_app). Setting the session preset wasn't in the sample code so I removed it and the crash disappeared.  I then tried moving it to after the addInput is called based on the theory that the previous uses of the camera had put it in an unexpected state and assigning the camera to the current session might clear that up. It's working for me in the CardScan Example app and also in my actual application.