### PR TITLE
Reintroduce cardverify func

### DIFF
--- a/CardScan/Classes/CreditCardUtils.swift
+++ b/CardScan/Classes/CreditCardUtils.swift
@@ -273,12 +273,17 @@ public struct CreditCardUtils {
         return prefixes.filter { cardNumber.hasPrefix($0) }.count > 0
     }
     
+    //TODO: Will be replaced with `formatCardNumber` in future version
+    public static func format(number: String) -> String {
+        return formatCardNumber(cardNumber: number)
+    }
+    
     /**
         Returns the card number formatted for display
         -   Parameter cardNumber: The card number as a string
         -   Returns: The card number formatted
      */
-    public static func format(cardNumber: String) -> String {
+    public static func formatCardNumber(cardNumber: String) -> String {
         if cardNumber.count == maxPanLength {
             return format16(cardNumber: cardNumber)
         } else if cardNumber.count == maxPanLengthAmericanExpress {
@@ -308,5 +313,28 @@ public struct CreditCardUtils {
             displayNumber += String(char)
         }
         return displayNumber
+    }
+}
+
+//TODO: Added extension to make older network changes available, will remove in future version
+extension CreditCardUtils {
+    public static func isVisa(number: String) -> Bool {
+        return determineCardNetwork(cardNumber: number) == CardNetwork.VISA
+    }
+    
+    public static func isAmex(number: String) -> Bool {
+        return determineCardNetwork(cardNumber: number) == CardNetwork.AMEX
+    }
+    
+    public static func isDiscover(number: String) -> Bool {
+        return determineCardNetwork(cardNumber: number) == CardNetwork.DISCOVER
+    }
+    
+    public static func isMastercard(number: String) -> Bool {
+        return determineCardNetwork(cardNumber: number) == CardNetwork.MASTERCARD
+    }
+    
+    public static func isUnionPay(number: String) -> Bool {
+        return determineCardNetwork(cardNumber: number) == CardNetwork.UNIONPAY
     }
 }

--- a/CardScan/Classes/CreditCardUtils.swift
+++ b/CardScan/Classes/CreditCardUtils.swift
@@ -293,6 +293,24 @@ public struct CreditCardUtils {
         }
     }
     
+    /**
+        Returns the card's expiration date formatted for display
+        -   Parameters:
+                -   expMonth: The expiration month as a string
+                -   expYear: The expiration year as a string
+        -   Returns: The card's expiration date formatted as MM/YY
+     */
+    public static func formatExpirationDate(expMonth: String, expYear: String) -> String {
+        var month = expMonth
+        let year = "\(expYear.suffix(2))"
+        
+        if expMonth.count == 1 {
+            month = "0\(expMonth)"
+        }
+        
+        return "\(month)/\(year)"
+    }
+    
     static func format15(cardNumber: String) -> String {
         var displayNumber = ""
         for (idx, char) in cardNumber.enumerated() {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -290,7 +290,7 @@ import UIKit
         // we're assuming that the image takes up the full width and that
         // video has the same aspect ratio of the screen
         DispatchQueue.main.async {
-            self.cardNumberLabel.text = CreditCardUtils.format(cardNumber: number)
+            self.cardNumberLabel.text = CreditCardUtils.format(number: number)
             if self.cardNumberLabel.isHidden {
                 self.cardNumberLabel.fadeIn()
             }


### PR DESCRIPTION
Put in the credit card functions used in `PaymentCard` of `CardVerify` but encapsulated it in our new functions. Hopefully will ween off old functions and only use CreditCardUtils.