### PR TITLE
providing client-side function with current frames number and predicted number

### DIFF
--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -60,7 +60,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, predictedNumberPredicate: (String?, String) -> Bool ) -> (String?, Expiry?, Bool, Bool) {
+    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, predictedNumberPredicate: (String?, String) -> Bool = { _, _ in true } ) -> (String?, Expiry?, Bool, Bool) {
         let number = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: predictedNumberPredicate)
 
         if self.firstResult == nil && number != nil {
@@ -133,7 +133,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool) -> String? {
+    public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool = { _, _ in true } ) -> String? {
         return self.perform(croppedCardImage: rawImage, squareCardImage: nil, fullCardImage: nil, predictedNumberPredicate: predicate)
     }
 }

--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -81,7 +81,7 @@ public class Ocr {
         let expiryResult = self.expiries.sorted { $0.1 > $1.1 }.map { $0.0 }.first
         let done = interval >= self.errorCorrectionDuration
         let foundNumberInThisScan = number != nil
-
+        
         if interval >= (self.errorCorrectionDuration / 2.0) {
             return (numberResult, expiryResult, done, foundNumberInThisScan)
         } else {

--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -60,7 +60,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, predictedNumberPredicate: (String?, String) -> Bool = { _, _ in true } ) -> (String?, Expiry?, Bool, Bool) {
+    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, predictedNumberPredicate: (String?, String) -> Bool = { _,_ in true } ) -> (String?, Expiry?, Bool, Bool) {
         let number = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: predictedNumberPredicate)
 
         if self.firstResult == nil && number != nil {
@@ -90,7 +90,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func perform(croppedCardImage: CGImage, squareCardImage: CGImage?, fullCardImage: CGImage?, predictedNumberPredicate: (String? , String) -> Bool ) -> String? {
+    public func perform(croppedCardImage: CGImage, squareCardImage: CGImage?, fullCardImage: CGImage?, predictedNumberPredicate: (String? , String) -> Bool = { _,_ in true } ) -> String? {
         var findFour = FindFourOcr()
         var number = findFour.predict(image: UIImage(cgImage: croppedCardImage))
         
@@ -133,7 +133,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool = { _, _ in true } ) -> String? {
+    public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool = { _,_ in true } ) -> String? {
         return self.perform(croppedCardImage: rawImage, squareCardImage: nil, fullCardImage: nil, predictedNumberPredicate: predicate)
     }
 }

--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -81,7 +81,7 @@ public class Ocr {
         let expiryResult = self.expiries.sorted { $0.1 > $1.1 }.map { $0.0 }.first
         let done = interval >= self.errorCorrectionDuration
         let foundNumberInThisScan = number != nil
-    
+
         if interval >= (self.errorCorrectionDuration / 2.0) {
             return (numberResult, expiryResult, done, foundNumberInThisScan)
         } else {
@@ -136,5 +136,4 @@ public class Ocr {
     public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool) -> String? {
         return self.perform(croppedCardImage: rawImage, squareCardImage: nil, fullCardImage: nil, predictedNumberPredicate: predicate)
     }
-    
 }

--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -60,8 +60,8 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, predictedNumberPredicate: (String?, String) -> Bool = { _,_ in true } ) -> (String?, Expiry?, Bool, Bool) {
-        let number = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: predictedNumberPredicate)
+    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage, useCurrentFrameNumber: (String?, String) -> Bool = { _,_ in true } ) -> (String?, Expiry?, Bool, Bool) {
+        let number = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, useCurrentFrameNumber: useCurrentFrameNumber)
 
         if self.firstResult == nil && number != nil {
             self.firstResult = Date()
@@ -90,13 +90,13 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func perform(croppedCardImage: CGImage, squareCardImage: CGImage?, fullCardImage: CGImage?, predictedNumberPredicate: (String? , String) -> Bool = { _,_ in true } ) -> String? {
+    public func perform(croppedCardImage: CGImage, squareCardImage: CGImage?, fullCardImage: CGImage?, useCurrentFrameNumber: (String? , String) -> Bool = { _,_ in true } ) -> String? {
         var findFour = FindFourOcr()
         var number = findFour.predict(image: UIImage(cgImage: croppedCardImage))
         
         if let currentNumber = number {
             let errorCorrectedNumber = self.numbers.sorted { $0.1 > $1.1 }.map { $0.0 }.first
-            if !predictedNumberPredicate(errorCorrectedNumber, currentNumber) {
+            if !useCurrentFrameNumber(errorCorrectedNumber, currentNumber) {
                 number = nil
             }
         }
@@ -133,7 +133,7 @@ public class Ocr {
     }
     
     @available(iOS 11.2, *)
-    public func perform(for rawImage: CGImage, predicate: (String?, String) -> Bool = { _,_ in true } ) -> String? {
-        return self.perform(croppedCardImage: rawImage, squareCardImage: nil, fullCardImage: nil, predictedNumberPredicate: predicate)
+    public func perform(for rawImage: CGImage, userCurrentFrameNumber: (String?, String) -> Bool = { _,_ in true } ) -> String? {
+        return self.perform(croppedCardImage: rawImage, squareCardImage: nil, fullCardImage: nil, useCurrentFrameNumber: userCurrentFrameNumber)
     }
 }

--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -59,15 +59,23 @@ public class Ocr {
         self.scanStats.endTime = Date()
     }
     
+    /**
+        - Parameters:
+            -   croppedCardImage: A credit card sized image
+            -   squareCardImage: A square sized image
+            -   fullCardImage: A fullscreen sized image
+        -   Returns:
+            - (currentFrameNumber, predictedNumber, expiryResult, done, foundNumberInThisScan)
+     */
     @available(iOS 11.2, *)
-    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage) -> (String?, Expiry?, Bool, Bool) {
-        let number = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage)
+    public func performWithErrorCorrection(for croppedCardImage: CGImage, squareCardImage: CGImage, fullCardImage: CGImage) -> (String?, String?, Expiry?, Bool, Bool) {
+        let currentNumber = self.perform(croppedCardImage: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage)
 
-        if self.firstResult == nil && number != nil {
+        if self.firstResult == nil && currentNumber != nil {
             self.firstResult = Date()
         }
         
-        if let number = number {
+        if let number = currentNumber {
             self.numbers[number] = (self.numbers[number] ?? 0) + 1
         }
         
@@ -80,12 +88,12 @@ public class Ocr {
         let numberResult = self.numbers.sorted { $0.1 > $1.1 }.map { $0.0 }.first
         let expiryResult = self.expiries.sorted { $0.1 > $1.1 }.map { $0.0 }.first
         let done = interval >= self.errorCorrectionDuration
-        let foundNumberInThisScan = number != nil
+        let foundNumberInThisScan = currentNumber != nil
         
         if interval >= (self.errorCorrectionDuration / 2.0) {
-            return (numberResult, expiryResult, done, foundNumberInThisScan)
+            return (currentNumber, numberResult, expiryResult, done, foundNumberInThisScan)
         } else {
-            return (numberResult, nil, done, foundNumberInThisScan)
+            return (currentNumber, numberResult, nil, done, foundNumberInThisScan)
         }
     }
     

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -52,7 +52,7 @@ public protocol TestingImageDataSource: AnyObject {
     @objc open func onScannedCard(number: String, expiryYear: String?, expiryMonth: String?, scannedImage: UIImage?) { }
     @objc open func showCardNumber(_ number: String, expiry: String?) { }
     @objc open func onCameraPermissionDenied(showedPrompt: Bool) { }
-    @objc open func usePredictedCardNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool { return true }
+    @objc open func useCurrentFrameNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool { return true }
     
     //MARK: -Torch Logic
     public func toggleTorch() {
@@ -346,7 +346,7 @@ public protocol TestingImageDataSource: AnyObject {
     func blockingOcrModel(squareCardImage: CGImage, fullCardImage: CGImage) {
         let croppedCardImage = toCardImage(squareCardImage: squareCardImage)
         
-        let (number, expiry, done, foundNumberInThisScan) = ocr.performWithErrorCorrection(for: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: self.usePredictedCardNumber(predictedNumber:currentFrameNumber:))
+        let (number, expiry, done, foundNumberInThisScan) = ocr.performWithErrorCorrection(for: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: self.useCurrentFrameNumber(predictedNumber:currentFrameNumber:))
         
         if let number = number {
             self.showCardNumber(number, expiry: expiry?.display())

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -52,7 +52,7 @@ public protocol TestingImageDataSource: AnyObject {
     @objc open func onScannedCard(number: String, expiryYear: String?, expiryMonth: String?, scannedImage: UIImage?) { }
     @objc open func showCardNumber(_ number: String, expiry: String?) { }
     @objc open func onCameraPermissionDenied(showedPrompt: Bool) { }
-    @objc open func useCurrentFrameNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool { return true }
+    @objc open func useCurrentFrameNumber(errorCorrectedNumber: String?, currentFrameNumber: String) -> Bool { return true }
     
     //MARK: -Torch Logic
     public func toggleTorch() {
@@ -346,7 +346,7 @@ public protocol TestingImageDataSource: AnyObject {
     func blockingOcrModel(squareCardImage: CGImage, fullCardImage: CGImage) {
         let croppedCardImage = toCardImage(squareCardImage: squareCardImage)
         
-        let (number, expiry, done, foundNumberInThisScan) = ocr.performWithErrorCorrection(for: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, predictedNumberPredicate: self.useCurrentFrameNumber(predictedNumber:currentFrameNumber:))
+        let (number, expiry, done, foundNumberInThisScan) = ocr.performWithErrorCorrection(for: croppedCardImage, squareCardImage: squareCardImage, fullCardImage: fullCardImage, useCurrentFrameNumber: self.useCurrentFrameNumber(errorCorrectedNumber:currentFrameNumber:))
         
         if let number = number {
             self.showCardNumber(number, expiry: expiry?.display())

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -304,6 +304,12 @@ import UIKit
         }
     }
     
+    public override func usePredictedCardNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool {
+        print("predicted number: \(predictedNumber)")
+        print("current number: \(currentFrameNumber)")
+        return true
+    }
+    
     override public func onScannedCard(number: String, expiryYear: String?, expiryMonth: String?, scannedImage: UIImage?) {
         
         if self.calledDelegate {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -304,9 +304,7 @@ import UIKit
         }
     }
     
-    public override func usePredictedCardNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool {
-        print("predicted number: \(predictedNumber)")
-        print("current number: \(currentFrameNumber)")
+    public override func useCurrentFrameNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool {
         return true
     }
     

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -304,7 +304,7 @@ import UIKit
         }
     }
     
-    public override func useCurrentFrameNumber(predictedNumber: String?, currentFrameNumber: String) -> Bool {
+    public override func useCurrentFrameNumber(errorCorrectedNumber : String?, currentFrameNumber: String) -> Bool {
         return true
     }
     


### PR DESCRIPTION
* Exposed the current frame's card number to the return of `OCR`'s `performWithErrorCorrection()`
* The function `uponPredictedCardNumber()` allows clients to handle the case where the predicted number and expected number do not align with their own implementation