### PR TITLE
Fixes orientation of preview layer to match device.

### DIFF
--- a/CardScan/Classes/PreviewView.swift
+++ b/CardScan/Classes/PreviewView.swift
@@ -54,6 +54,12 @@ public class PreviewView: UIView {
         }
         layer.videoGravity = .resizeAspectFill
         
+        let orientation = UIDevice.current.orientation
+        
+        if let videoOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue) {
+            layer.connection?.videoOrientation = videoOrientation
+        }
+        
         return layer
     }
     


### PR DESCRIPTION
This breaks the OCR recognition on the changed orientations, but it fixes the preview layer so it lines up with the device.