### PR TITLE
[RFC] protocol to extract ocr_result

### DIFF
--- a/CardScan/Classes/Ocr.swift
+++ b/CardScan/Classes/Ocr.swift
@@ -83,6 +83,18 @@ public class Ocr {
         let foundNumberInThisScan = number != nil
         
         if interval >= (self.errorCorrectionDuration / 2.0) {
+            var ocrResult: [String: Any] = [:]
+            if let number = numberResult {
+                ocrResult["bin"] = String(number.prefix(6))
+                ocrResult["last4"] = String(number.suffix(4))
+            }
+            
+            if let expiry = expiryResult {
+                ocrResult["exp_month"] = String(expiry.month)
+                ocrResult["exp_year"] = String(expiry.year)
+            }
+            
+            self.scanEventsDelegate?.onScanComplete(ocrResults: ocrResult)
             return (numberResult, expiryResult, done, foundNumberInThisScan)
         } else {
             return (numberResult, nil, done, foundNumberInThisScan)

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -17,6 +17,10 @@ public protocol TestingImageDataSource: AnyObject {
         self.scanEventsDelegate?.onNumberRecognized(number: number, expiry: expiry, numberBoundingBox: numberBoundingBox, expiryBoundingBox: expiryBoundingBox, croppedCardSize: croppedCardSize, squareCardImage: squareCardImage, fullCardImage: fullCardImage)
     }
     
+    public func onScanComplete(ocrResults: [String: Any]) {
+        self.scanEventsDelegate?.onScanComplete(ocrResults: ocrResults)
+    }
+    
     public func onScanComplete(scanStats: ScanStats) {
         // this shouldn't get called
     }

--- a/CardScan/Classes/ScanEventsProtocol.swift
+++ b/CardScan/Classes/ScanEventsProtocol.swift
@@ -9,5 +9,6 @@
 public protocol ScanEvents {
     mutating func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect, expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage)
     mutating func onScanComplete(scanStats: ScanStats)
+    mutating func onScanComplete(ocrResults: [String: Any])
     mutating func onFrameDetected(croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage)
 }

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -201,6 +201,10 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, FullScanString
         print("scan complete")
     }
     
+    func onScanComplete(ocrResults: [String : Any]) {
+        print("scan complete with ocr result")
+    }
+    
     @IBAction func scanWithStatsPress() {
         ScanViewController.configure(apiKey: "0xdeadbeef")
         guard let vc = ScanViewController.createViewController(withDelegate: self) else {


### PR DESCRIPTION
Overloaded `onScanComplete` protocol to extract ocr_result for CardVerify to add to `scan` object