### PR TITLE
Add protocol to enable extending the main loop

### DIFF
--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -41,6 +41,10 @@ import UIKit
     @objc func denyPermissionButton() -> String
 }
 
+public protocol MainLoopDelegate: class {
+    func shouldRunBaseMainLoop(fullCardImage: CGImage, roiRectangle: CGRect, scanViewController: ScanViewController) -> Bool
+}
+
 @objc public class CreditCard: NSObject {
     @objc public var number: String
     @objc public var expiryMonth: String?
@@ -89,6 +93,7 @@ import UIKit
     @objc public var allowSkip = false
     public var torchLevel: Float? 
     public var scanQrCode = false
+    public weak var mainLoopDelegate: MainLoopDelegate?
     @objc public var hideBackButtonImage = false
     @IBOutlet weak var backButtonImageToTextConstraint: NSLayoutConstraint!
     @IBOutlet weak var backButtonWidthConstraint: NSLayoutConstraint!
@@ -114,7 +119,7 @@ import UIKit
     
     @IBOutlet weak var debugImageView: UIImageView!
     @IBOutlet weak var previewView: PreviewView!
-    @IBOutlet weak var regionOfInterestLabel: UILabel!
+    @IBOutlet public weak var regionOfInterestLabel: UILabel!
     @IBOutlet weak var regionOfInterestAspectConstraint: NSLayoutConstraint!
     
     @IBOutlet weak var torchButton: UIButton!
@@ -339,6 +344,16 @@ import UIKit
     
     @IBAction func toggleTorch(_ sender: Any) {
         self.toggleTorch()
+    }
+    
+    // MARK: main loop
+    @available(iOS 11.2, *)
+    override public func blockingMlModel(fullCardImage: CGImage, roiRectangle: CGRect) {
+        guard mainLoopDelegate?.shouldRunBaseMainLoop(fullCardImage: fullCardImage, roiRectangle: roiRectangle, scanViewController: self) ?? true else {
+            return
+        }
+        
+        super.blockingMlModel(fullCardImage: fullCardImage, roiRectangle: roiRectangle)
     }
 }
 


### PR DESCRIPTION
This PR is a first step to enabling people to reuse our UI and image pipeline while dropping in their own ML (ie main loop). Since there isn't an elegant way to subclass storyview-based VCs, having a protocol + public variables should expose enough to accomplish a number of jobs.