### PR TITLE
add view obscuring during background 

### DIFF
--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -297,6 +297,11 @@ public protocol MainLoopDelegate: class {
         self.cornerView.layer.borderColor = self.cornerBorderColor
     }
     
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.removeBackgroundObservers()
+    }
+    
     public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
     }
@@ -382,6 +387,11 @@ extension ScanViewController {
          NotificationCenter.default.addObserver(self, selector: #selector(viewOnWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
          NotificationCenter.default.addObserver(self, selector: #selector(viewOnDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
      }
+    
+    func removeBackgroundObservers() {
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
 }
 
 // https://stackoverflow.com/a/53143736/947883

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -134,6 +134,7 @@ public protocol MainLoopDelegate: class {
     var denyPermissionButtonText = "OK"
     
     var calledDelegate = false
+    var blurViewTagOnBackground: Int = 9999
     
     @objc static public func createViewController(withDelegate delegate: ScanDelegate? = nil) -> ScanViewController? {
         // use default config
@@ -274,6 +275,7 @@ public protocol MainLoopDelegate: class {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        self.addBackgroundObservers()
         
         self.setStrings()
         self.setUiCustomization()
@@ -362,6 +364,25 @@ public protocol MainLoopDelegate: class {
     }
 }
 
+extension ScanViewController {
+     @objc func viewOnWillResignActive() {
+         let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
+         let blurEffectView = UIVisualEffectView(effect: blurEffect)
+         blurEffectView.tag = blurViewTagOnBackground
+         blurEffectView.frame = self.view.bounds
+         blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+         self.view.addSubview(blurEffectView)
+     }
+    
+     @objc func viewOnDidBecomeActive() {
+         self.view.viewWithTag(blurViewTagOnBackground)?.removeFromSuperview()
+     }
+     
+     func addBackgroundObservers() {
+         NotificationCenter.default.addObserver(self, selector: #selector(viewOnWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+         NotificationCenter.default.addObserver(self, selector: #selector(viewOnDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+     }
+}
 
 // https://stackoverflow.com/a/53143736/947883
 extension UIView {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -275,8 +275,7 @@ public protocol MainLoopDelegate: class {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        self.addBackgroundObservers()
-        
+
         self.setStrings()
         self.setUiCustomization()
         self.calledDelegate = false
@@ -295,6 +294,8 @@ public protocol MainLoopDelegate: class {
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(true)
         self.cornerView.layer.borderColor = self.cornerBorderColor
+        self.addBackgroundObservers()
+        
     }
     
     public override func viewWillDisappear(_ animated: Bool) {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -134,7 +134,7 @@ public protocol MainLoopDelegate: class {
     var denyPermissionButtonText = "OK"
     
     var calledDelegate = false
-    var blurViewTagOnBackground: Int = 9999
+    @objc var backgroundBlurEffectView: UIVisualEffectView?
     
     @objc static public func createViewController(withDelegate delegate: ScanDelegate? = nil) -> ScanViewController? {
         // use default config
@@ -372,16 +372,22 @@ public protocol MainLoopDelegate: class {
 
 extension ScanViewController {
      @objc func viewOnWillResignActive() {
-         let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
-         let blurEffectView = UIVisualEffectView(effect: blurEffect)
-         blurEffectView.tag = blurViewTagOnBackground
-         blurEffectView.frame = self.view.bounds
-         blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-         self.view.addSubview(blurEffectView)
+        let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.dark)
+        self.backgroundBlurEffectView = UIVisualEffectView(effect: blurEffect)
+
+        guard let backgroundBlurEffectView = self.backgroundBlurEffectView else {
+            return
+        }
+
+        backgroundBlurEffectView.frame = self.view.bounds
+        backgroundBlurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.view.addSubview(backgroundBlurEffectView)
      }
     
      @objc func viewOnDidBecomeActive() {
-         self.view.viewWithTag(blurViewTagOnBackground)?.removeFromSuperview()
+        if let backgroundBlurEffectView = self.backgroundBlurEffectView {
+            backgroundBlurEffectView.removeFromSuperview()
+        }
      }
      
      func addBackgroundObservers() {

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -275,7 +275,7 @@ public protocol MainLoopDelegate: class {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         self.setStrings()
         self.setUiCustomization()
         self.calledDelegate = false


### PR DESCRIPTION
Added view obscuring per Doyensec's suggestion: 
```To protect the iOS applications, implement a similar minor mitigation. Some of these include hiding the sensitive informations by using UIScreen you to detect when the screen is being captured or when the user move to the background the application```

Decided to add another pair of observers for when the application goes into background / foreground since delegate-communication won't work with parent-child relationship between `scanBaseViewController` and `scanViewController`. A few other reasons is that the notification handler in `scanBaseViewController` is used specifically for the `machineLearningQueue` and the view is only accessible in the `scanViewController` level. 
