### PR TITLE
Expose the OcrMainLoop variables as public

### DIFF
--- a/CardScan/Classes/CreditCardOcr/CreditCardOcrPrediction.swift
+++ b/CardScan/Classes/CreditCardOcr/CreditCardOcrPrediction.swift
@@ -8,33 +8,33 @@
 import Foundation
 
 public struct CreditCardOcrPrediction {
-    let image: CGImage
-    let number: String?
-    let expiryMonth: String?
-    let expiryYear: String?
-    let name: String?
-    let computationTime: Double
-    let numberBoxes: [CGRect]?
-    let expiryBoxes: [CGRect]?
-    let nameBoxes: [CGRect]?
+    public let image: CGImage
+    public let number: String?
+    public let expiryMonth: String?
+    public let expiryYear: String?
+    public let name: String?
+    public let computationTime: Double
+    public let numberBoxes: [CGRect]?
+    public let expiryBoxes: [CGRect]?
+    public let nameBoxes: [CGRect]?
     
     static func emptyPrediction(cgImage: CGImage) -> CreditCardOcrPrediction {
         CreditCardOcrPrediction(image: cgImage, number: nil, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
     }
     
-    var expiryForDisplay: String? {
+    public var expiryForDisplay: String? {
         guard let month = expiryMonth, let year = expiryYear else { return nil }
         return "\(month)/\(year)"
     }
     
-    var expiryAsUInt: (UInt, UInt)? {
+    public var expiryAsUInt: (UInt, UInt)? {
         guard let month = expiryMonth.flatMap({ UInt($0) }) else { return nil }
         guard let year = expiryYear.flatMap({ UInt($0) }) else { return nil }
         
         return (month, year)
     }
     
-    var numberBox: CGRect? {
+    public var numberBox: CGRect? {
         let xmin = numberBoxes?.map { $0.minX }.min() ?? 0.0
         let xmax = numberBoxes?.map { $0.maxX }.max() ?? 0.0
         let ymin = numberBoxes?.map { $0.minY }.min() ?? 0.0
@@ -42,7 +42,7 @@ public struct CreditCardOcrPrediction {
         return CGRect(x: xmin, y: ymin, width: (xmax - xmin), height: (ymax - ymin))
     }
     
-    var expiryBox: CGRect? {
+    public var expiryBox: CGRect? {
         return expiryBoxes.flatMap { $0.first }
     }
     

--- a/CardScan/Classes/CreditCardOcr/CreditCardOcrResult.swift
+++ b/CardScan/Classes/CreditCardOcr/CreditCardOcrResult.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public class CreditCardOcrResult: MachineLearningResult {
-    let mostRecentPrediction: CreditCardOcrPrediction
-    let number: String
-    let expiry: String?
-    let name: String?
-    let isFinished: Bool
+    public let mostRecentPrediction: CreditCardOcrPrediction
+    public let number: String
+    public let expiry: String?
+    public let name: String?
+    public let isFinished: Bool
     
     init(mostRecentPrediction: CreditCardOcrPrediction, number: String, expiry: String?, name: String?, isFinished: Bool, duration: Double, frames: Int) {
         self.mostRecentPrediction = mostRecentPrediction
@@ -24,10 +24,10 @@ public class CreditCardOcrResult: MachineLearningResult {
         super.init(duration: duration, frames: frames)
     }
     
-    var expiryMonth: String? {
+    public var expiryMonth: String? {
         return expiry.flatMap { $0.split(separator: "/").first.map { String($0) }}
     }
-    var expiryYear: String? {
+    public var expiryYear: String? {
         return expiry.flatMap { $0.split(separator: "/").last.map { String($0) }}
     }
 }

--- a/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/Classes/ScanBaseViewController.swift
@@ -201,6 +201,10 @@ public protocol TestingImageDataSource: AnyObject {
         self.ocrMainLoop()?.mainLoopDelegate = self
         self.previewView?.videoPreviewLayer.session = self.videoFeed.session
         
+        if testingImageDataSource != nil {
+            self.ocrMainLoop()?.imageQueueSize = 20
+        }
+        
         self.videoFeed.pauseSession()
         //Apple example app sets up in viewDidLoad: https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/avcam_building_a_camera_app
         self.videoFeed.setup(captureDelegate: self, completion: { success in
@@ -304,8 +308,10 @@ public protocol TestingImageDataSource: AnyObject {
         // we allow apps that integrate to supply their own sequence of images
         // for use in testing
         if let dataSource = self.testingImageDataSource {
-            let (_, fullImage) = dataSource.nextSquareAndFullImage() ?? (nil, fullCardImage)
-            let _ = mainLoop?.blockingPush(fullImage: fullImage, roiRectangle: roiRectInPixels)
+            guard let (_, fullImage) = dataSource.nextSquareAndFullImage() else {
+                return
+            }
+            mainLoop?.push(fullImage: fullImage, roiRectangle: roiRectInPixels)
         } else {
             if #available(iOS 11.2, *) {
                 mainLoop?.push(fullImage: fullCardImage, roiRectangle: roiRectInPixels)

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -25,6 +25,10 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, FullScanString
     var currentTestImages: [CGImage]?
     
     func nextSquareAndFullImage() -> (CGImage, CGImage)? {
+        if self.currentTestImages?.first == nil {
+            self.currentTestImages = self.testImages.compactMap { $0.cgImage }
+        }
+        
         guard let fullCardImage = self.currentTestImages?.first else {
             print("could not get full size test image")
             return nil


### PR DESCRIPTION
Also includes changes to related objects around the OcrMainLoop and gets rid of `blockingPush` from the API. If one wants to do a blockingPush they should do it themselves on top of our API.