### PR TITLE
Backgrounding logic patch

### DIFF
--- a/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
+++ b/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
@@ -260,6 +260,8 @@ public class OcrMainLoop : MachineLearningLoop {
     }
     
     @objc func didBecomeActive() {
+        // isBackground is true only when the queues are suspended.
+        // isBackground flag is used as a proxy areQueuesSuspended flag to avoid crash
         mutexQueue.sync {
             if self.inBackground {
                 for queue in machineLearningQueues {


### PR DESCRIPTION
```isBackground``` is true only when the queues are suspended. Use ```isBackground``` flag as a proxy ```areQueuesSuspended``` flag to avoid crash.

Note: I know I shouldn't put the queues in the mutexQueue but I felt like I should since its conditional upon the state of the background flag