### PR TITLE
[RFC] Rotation

### DIFF
--- a/CardScan/Classes/PreviewView.swift
+++ b/CardScan/Classes/PreviewView.swift
@@ -53,7 +53,6 @@ public class PreviewView: UIView {
             fatalError("Expected `AVCaptureVideoPreviewLayer` type for layer. Check PreviewView.layerClass implementation.")
         }
         layer.videoGravity = .resizeAspectFill
-        layer.connection?.videoOrientation = self.videoOrientation ?? .portrait
         return layer
     }
     

--- a/CardScan/Classes/VideoFeed.swift
+++ b/CardScan/Classes/VideoFeed.swift
@@ -13,6 +13,7 @@ class VideoFeed {
     }
     
     let session = AVCaptureSession()
+    weak var previewViewDelegate: PreviewViewOrientation?
     private var isSessionRunning = false
     private let sessionQueue = DispatchQueue(label: "session queue")
     private var setupResult: SessionSetupResult = .success
@@ -132,6 +133,10 @@ class VideoFeed {
             self.videoDeviceConnection = videoDeviceOutput.connection(with: .video)
             if self.videoDeviceConnection?.isVideoOrientationSupported ?? false {
                 self.videoDeviceConnection?.videoOrientation = self.videoOrientation ?? .portrait
+            }
+            
+            DispatchQueue.main.async {
+                self.previewViewDelegate?.setPreviewViewVideoOrientation()
             }
             
         } catch {

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -156,6 +156,9 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, FullScanString
         self.present(vc, animated: true)
     }
     
+    func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect, expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?) { }
+    func onScanComplete(scanStats: ScanStats) {}
+    func onFrameDetected(croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?) {}
     
     @IBAction func scanWithTimeoutPress() {
         guard let vc = ScanViewController.createViewController(withDelegate: self) else {
@@ -192,18 +195,6 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, FullScanString
         vc.testingImageDataSource = self
         vc.showDebugImageView = true
         self.present(vc, animated: true)
-    }
-    
-    func onFrameDetected(croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage) {
-        print("frame detected")
-    }
-    
-    func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect, expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage) {
-        print("number recognized")
-    }
-    
-    func onScanComplete(scanStats: ScanStats) {
-        print("scan complete")
     }
     
     @IBAction func scanWithStatsPress() {


### PR DESCRIPTION
In Apple's camera example app, they initialize the preview view orientation within the video feed session configuration. I didn't want to set a `previewView` reference in `VideoFeed` so I created a protocol to call the orientation setting within `VideoFeed`. 

Test in release build configuration