### PR TITLE
Sets the default for the iPad to a formSheet

### DIFF
--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -149,10 +149,19 @@ import UIKit
         // The forced unwrap here is intentional -- we expect this to crash
         // if someone uses it with an invalid bundle
         let bundle = CSBundle.bundle()!
-        
         let storyboard = UIStoryboard(name: "CardScan", bundle: bundle)
         let viewController = storyboard.instantiateViewController(withIdentifier: "scanCardViewController") as! ScanViewController
             viewController.scanDelegate = delegate
+        
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            // For the iPad you can use the full screen style but you have to select "requires full screen" in
+            // the Info.plist to lock it in portrait mode. For iPads, we recommend using a formSheet, which
+            // handles all orientations correctly.
+            viewController.modalPresentationStyle = .formSheet
+        } else {
+            viewController.modalPresentationStyle = .fullScreen
+        }
+        
         return viewController
     }
     

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -118,7 +118,6 @@ class ViewController: UIViewController, ScanEvents, ScanDelegate, FullScanString
             return
         }
         
-        vc.allowSkip = true
         self.present(vc, animated: true)
     }
     

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ CardScan iOS installation guide
 * [Requirements](#requirements)
 * [Installation](#installation)
 * [Permissions](#permissions)
+* [iPad support](#ipad-support)
 * [Configure CardScan (Swift)](#configure-cardscan-swift)
 * [Using CardScan (Swift)](#using-cardscan-swift)
 * [iOS 10 and older (Swift)](#ios-10-and-older-swift)
@@ -62,6 +63,14 @@ github "getbouncer/cardscan-ios" "master"
 ```
 
 Follow the [Carthage instructions for building for iOS](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos) 
+
+## iPad Support
+
+CardScan defaults to a `formSheet` for the iPad, which handles all
+screen orientations and autorotation correctly. However, if you'd like
+to use CardScan in full screen mode instead, make sure to select the
+`Requires full screen` option in your Info.plist file via XCode, or
+else non-portrait orientations won't work.
 
 ## Permissions
 


### PR DESCRIPTION
On the iPad if you don't select "requires full screen" in the `Info.plist` file then it won't use the standard mechanisms for locking the screen orientation and our full screen viewcontroller won't work.

This patch sets the presentation style to `formSheet` by default for iPads and adds a comment to the code + updates the README to let people know.