### PR TITLE
Ocr main loop deadlock bug fix

### DIFF
--- a/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
+++ b/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
@@ -149,14 +149,14 @@ open class OcrMainLoop : MachineLearningLoop {
     // Make sure you call this from the main dispatch queue
     func userCancelled() {
         userDidCancel = true
-        //mutexQueue.sync { [weak self] in
-            //guard let self = self else { return }
+        mutexQueue.sync { [weak self] in
+            guard let self = self else { return }
             if self.scanStats.success == nil {
                 self.scanStats.success = false
                 self.scanStats.endTime = Date()
                 self.mainLoopDelegate = nil
             }
-        //}
+        }
     }
     
     public func push(fullImage: CGImage, roiRectangle: CGRect) {
@@ -213,8 +213,6 @@ open class OcrMainLoop : MachineLearningLoop {
             let prediction = ocr.recognizeCard(in: image, roiRectangle: roi)
             self?.mutexQueue.async {
                 guard let self = self else { return }
-                print("sleeping")
-                sleep(20)
                 self.scanStats.scans += 1
                 let delegate = self.mainLoopDelegate
                 DispatchQueue.main.async { [weak self] in
@@ -225,10 +223,8 @@ open class OcrMainLoop : MachineLearningLoop {
                 }
                 guard let result = self.combine(prediction: prediction), result.isFinished else {
                     self.postAnalyzerToQueueAndRun(ocr: ocr)
-                    print("done sleeping, post")
                     return
                 }
-                print("done sleeping, exit")
             }
         }
     }

--- a/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
+++ b/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
@@ -147,14 +147,14 @@ open class OcrMainLoop : MachineLearningLoop {
     // Make sure you call this from the main dispatch queue
     func userCancelled() {
         userDidCancel = true
-        mutexQueue.sync { [weak self] in
-            guard let self = self else { return }
+        //mutexQueue.sync { [weak self] in
+            //guard let self = self else { return }
             if self.scanStats.success == nil {
                 self.scanStats.success = false
                 self.scanStats.endTime = Date()
                 self.mainLoopDelegate = nil
             }
-        }
+        //}
     }
     
     public func push(fullImage: CGImage, roiRectangle: CGRect) {
@@ -211,6 +211,8 @@ open class OcrMainLoop : MachineLearningLoop {
             let prediction = ocr.recognizeCard(in: image, roiRectangle: roi)
             self?.mutexQueue.async {
                 guard let self = self else { return }
+                print("sleeping")
+                sleep(20)
                 self.scanStats.scans += 1
                 let delegate = self.mainLoopDelegate
                 DispatchQueue.main.async { [weak self] in
@@ -221,8 +223,10 @@ open class OcrMainLoop : MachineLearningLoop {
                 }
                 guard let result = self.combine(prediction: prediction), result.isFinished else {
                     self.postAnalyzerToQueueAndRun(ocr: ocr)
+                    print("done sleeping, post")
                     return
                 }
+                print("done sleeping, exit")
             }
         }
     }

--- a/CardScan/Classes/ScanViewController.swift
+++ b/CardScan/Classes/ScanViewController.swift
@@ -306,12 +306,6 @@ import UIKit
         super.viewWillAppear(true)
         self.cornerView.layer.borderColor = self.cornerBorderColor
         self.addBackgroundObservers()
-        
-    }
-    
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.removeBackgroundObservers()
     }
     
     public override func viewDidLayoutSubviews() {
@@ -393,17 +387,14 @@ extension ScanViewController {
         if let backgroundBlurEffectView = self.backgroundBlurEffectView {
             backgroundBlurEffectView.removeFromSuperview()
         }
+        cardNumberLabel.isHidden = true
+        expiryLabel.isHidden = true
      }
      
      func addBackgroundObservers() {
          NotificationCenter.default.addObserver(self, selector: #selector(viewOnWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
          NotificationCenter.default.addObserver(self, selector: #selector(viewOnDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
      }
-    
-    func removeBackgroundObservers() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
-    }
 }
 
 // https://stackoverflow.com/a/53143736/947883


### PR DESCRIPTION
Previously by having some of our queue clean up logic live in the `deinit` function of our main loop, it got hard to reason about because objects and deinit in subtle ways (e.g., see the first commit of this PR to see the bug). This PR cleans up our backgrounding logic, simplifies our use of dispatch queues, and removes the logic we had on `deinit` previously.

This new backgrounding logic is much easier to reason about, so hopefully this one will stick.