### PR TITLE
Fix bug with Xcode 12 beta 3 compiler optimizations

### DIFF
--- a/CardScan/Classes/Expiry.swift
+++ b/CardScan/Classes/Expiry.swift
@@ -1,9 +1,15 @@
 import Foundation
 
-public struct Expiry: Hashable {
+public class Expiry: Hashable {
     public let string: String
     public let month: UInt
     public let year: UInt
+    
+    init(string: String, month: UInt, year: UInt) {
+        self.string = string
+        self.month = month
+        self.year = year
+    }
     
     public static func == (lhs: Expiry, rhs: Expiry) -> Bool {
         return lhs.string == rhs.string


### PR DESCRIPTION
When the clang code generator and swift compiler use optimizations in Xcode 12 Beta 3 CardScan doesn't compile. To reproduce:

- Download Xcode 12 Beta 3
- Choose "build for any device"
- Run an "Archive"