### PR TITLE
Added support for regional cards

### DIFF
--- a/CardScan/Classes/CardNetwork.swift
+++ b/CardScan/Classes/CardNetwork.swift
@@ -15,6 +15,7 @@ import Foundation
     case UNIONPAY
     case JCB
     case DINERSCLUB
+    case REGIONAL
     case UNKNOWN
     
     public func toString() -> String {
@@ -26,6 +27,7 @@ import Foundation
         case .UNIONPAY: return "Union Pay"
         case .JCB: return "Jcb"
         case .DINERSCLUB: return "Diners Club"
+        case .REGIONAL: return "Regional"
         case .UNKNOWN: return "Unknown"
         }
     }

--- a/CardScan/Classes/CreditCardUtils.swift
+++ b/CardScan/Classes/CreditCardUtils.swift
@@ -19,6 +19,8 @@ public struct CreditCardUtils {
                                      "67"]
     private static let prefixesUnionPay = ["62"]
     private static let prefixesVisa = ["4"]
+
+    public static var prefixesRegional: [String] = []
     
     /**
         Checks if the card number is valid.
@@ -246,6 +248,8 @@ public struct CreditCardUtils {
             return CardNetwork.MASTERCARD
         case hasAnyPrefix(cardNumber: cardNumber, prefixes: prefixesUnionPay):
             return CardNetwork.UNIONPAY
+        case hasAnyPrefix(cardNumber: cardNumber, prefixes: prefixesRegional):
+            return CardNetwork.REGIONAL
         default:
             return CardNetwork.UNKNOWN
         }

--- a/CardScan/Classes/CreditCardUtils.swift
+++ b/CardScan/Classes/CreditCardUtils.swift
@@ -23,6 +23,13 @@ public struct CreditCardUtils {
     public static var prefixesRegional: [String] = []
     
     /**
+        Adds the BINs implemented by the MIR network in Russia as regional cards
+     */
+    public static func addMirSupport() {
+        prefixesRegional += ["2200", "2201", "2202", "2203", "2204"]
+    }
+    
+    /**
         Checks if the card number is valid.
         -   Parameter cardNumber: The card number as a string .
         -   Returns: `true` if valid, `false` otherwise

--- a/Example/CardScan/Base.lproj/Main.storyboard
+++ b/Example/CardScan/Base.lproj/Main.storyboard
@@ -126,12 +126,20 @@
                                     <segue destination="QHk-Pe-Pgw" kind="show" id="KAt-Cl-VDw"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NWV-5A-wUg">
+                                <rect key="frame" x="145.5" y="151.5" width="84" height="30"/>
+                                <state key="normal" title="Scan w/ MIR"/>
+                                <connections>
+                                    <action selector="scanWithMirPress" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Py8-zH-DVS"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="qlz-Ds-Znv" firstAttribute="top" secondItem="9tR-DO-gyb" secondAttribute="bottom" constant="16" id="1PH-rJ-mXS"/>
                             <constraint firstItem="ohs-2Q-mlC" firstAttribute="top" secondItem="f3P-G8-yKq" secondAttribute="bottom" constant="8" id="2fc-SR-27T"/>
                             <constraint firstItem="ohs-2Q-mlC" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="16" id="420-Q5-1Ny"/>
+                            <constraint firstItem="NWV-5A-wUg" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="5mz-pX-oBH"/>
                             <constraint firstItem="f3P-G8-yKq" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="8CR-et-Rxz"/>
                             <constraint firstItem="qlz-Ds-Znv" firstAttribute="centerY" secondItem="kh9-bI-dsS" secondAttribute="centerY" id="AkZ-f5-Cw0"/>
                             <constraint firstItem="LBI-Nj-Ojb" firstAttribute="top" secondItem="pIK-as-bko" secondAttribute="bottom" constant="8" id="DKk-6B-vtM"/>
@@ -154,6 +162,7 @@
                             <constraint firstItem="HGF-3W-kd7" firstAttribute="trailing" secondItem="kh9-bI-dsS" secondAttribute="trailingMargin" id="jJ2-Kn-FQ2"/>
                             <constraint firstItem="HGF-3W-kd7" firstAttribute="top" secondItem="LBI-Nj-Ojb" secondAttribute="bottom" constant="8" id="n9T-02-cay"/>
                             <constraint firstItem="6NY-p4-OvD" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="sRZ-M5-dWl"/>
+                            <constraint firstItem="f3P-G8-yKq" firstAttribute="top" secondItem="NWV-5A-wUg" secondAttribute="bottom" constant="8" id="snC-PU-qzF"/>
                             <constraint firstItem="qlz-Ds-Znv" firstAttribute="trailing" secondItem="kh9-bI-dsS" secondAttribute="trailingMargin" id="tRj-Xx-bJf"/>
                             <constraint firstItem="Hq5-Pp-QoB" firstAttribute="centerX" secondItem="kh9-bI-dsS" secondAttribute="centerX" id="wMV-F7-j4i"/>
                         </constraints>

--- a/Example/CardScan/ViewController.swift
+++ b/Example/CardScan/ViewController.swift
@@ -36,6 +36,15 @@ class ViewController: UIViewController {
             self.scanCardButton.isHidden = true
         }
     }
+    @IBAction func scanWithMirPress() {
+        guard let vc = ScanViewController.createViewController(withDelegate: self) else {
+            print("scan view controller not supported on this hardware")
+            return
+        }
+        CreditCardUtils.prefixesRegional = ["2200", "2201", "2202", "2203", "2204"]
+        
+        self.present(vc, animated: true)
+    }
     
     @IBAction func scanQrCodePress() {
         if #available(iOS 11.2, *) {

--- a/Example/CardScan_ExampleTests/CardScan_CardUtilsTests.swift
+++ b/Example/CardScan_ExampleTests/CardScan_CardUtilsTests.swift
@@ -73,4 +73,11 @@ class CardScan_CardUtilsTests: XCTestCase {
         XCTAssert(CreditCardUtils.isValidDate(expMonth: expMonth, expYear: validExpYear))
         XCTAssert(!CreditCardUtils.isValidDate(expMonth: expMonth, expYear: invalidExpYear))
     }
+    
+    func testRegionalCards() {
+        XCTAssert(!CreditCardUtils.isValidNumber(cardNumber: "2200000000000061"))
+        CreditCardUtils.prefixesRegional = ["2200"]
+        XCTAssert(CreditCardUtils.isValidNumber(cardNumber: "2200000000000061"))
+        CreditCardUtils.prefixesRegional = []
+    }
 }

--- a/Example/CardScan_ExampleTests/CardScan_CardUtilsTests.swift
+++ b/Example/CardScan_ExampleTests/CardScan_CardUtilsTests.swift
@@ -80,4 +80,11 @@ class CardScan_CardUtilsTests: XCTestCase {
         XCTAssert(CreditCardUtils.isValidNumber(cardNumber: "2200000000000061"))
         CreditCardUtils.prefixesRegional = []
     }
+    
+    func testMirCards() {
+        XCTAssert(!CreditCardUtils.isValidNumber(cardNumber: "2200000000000061"))
+        CreditCardUtils.addMirSupport()
+        XCTAssert(CreditCardUtils.isValidNumber(cardNumber: "2200000000000061"))
+        CreditCardUtils.prefixesRegional = []
+    }
 }


### PR DESCRIPTION
Apps can add their own BINs to our list of supported card number prefixes using the `CreditCardUtils.prefixesRegional` public and static variable