### PR TITLE
Add user_canceled to stats and add send stats on cancel

### DIFF
--- a/CardScan/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
+++ b/CardScan/CardScan/Classes/CreditCardOcr/OcrMainLoop.swift
@@ -141,6 +141,7 @@ open class OcrMainLoop : MachineLearningLoop {
         userDidCancel = true
         mutexQueue.sync { [weak self] in
             guard let self = self else { return }
+            self.scanStats.userCanceled = userDidCancel
             if self.scanStats.success == nil {
                 self.scanStats.success = false
                 self.scanStats.endTime = Date()

--- a/CardScan/CardScan/Classes/ScanStats.swift
+++ b/CardScan/CardScan/Classes/ScanStats.swift
@@ -29,6 +29,7 @@ public struct ScanStats {
     public var expiryBoxes: [CGRect]?
     public var cardsDetected = 0
     public var permissionGranted: Bool?
+    public var userCanceled: Bool = false
     
     init() {
         var systemInfo = utsname()
@@ -58,7 +59,8 @@ public struct ScanStats {
                 "duration": self.duration(),
                 "model": self.model ?? "unknown",
                 "permission_granted": self.permissionGranted.map { $0 ? "granted" : "denied" } ?? "not_determined",
-                "device_type": self.deviceType ?? ""]
+                "device_type": self.deviceType ?? "",
+                "user_canceled": self.userCanceled]
     }
     
     public func duration() -> Double {

--- a/CardScan/CardScan/Classes/SimpleScanViewController.swift
+++ b/CardScan/CardScan/Classes/SimpleScanViewController.swift
@@ -384,6 +384,7 @@ open class SimpleScanViewController: ScanBaseViewController {
     // MARK: -UI event handlers
     @objc open func cancelButtonPress() {
         delegate?.userDidCancelSimple(self)
+        self.cancelScan()
     }
     
     @objc open func torchButtonPress() {


### PR DESCRIPTION
* Added the `user_canceled` stat to `scanStats`  
* Added logic to send stats whenever `SimpleScan` is canceled 

#### Stats on camera permission not granted and scan canceled:
```ruby
{
  "duration" : 1.8399670124053955,
  "model" : "ssd+apple",
  "device_type" : "iPhone13,3",
  "torch_on" : false,
  "success" : false,
  "orientation" : "portrait",
  "scans" : 0,
  "permission_granted" : "denied",
  "user_canceled" : true,
  "cards_detected" : 0
}
```
#### Stats camera permission granted and scan canceled
```ruby
{
  "success" : false,
  "duration" : 2.7851790189743042,
  "orientation" : "portrait",
  "device_type" : "iPhone13,3",
  "user_canceled" : true,
  "model" : "ssd+apple",
  "scans" : 35,
  "torch_on" : false,
  "cards_detected" : 0,
  "permission_granted" : "granted"
}
```

#### Stats on Scan Complete:
```ruby
{
  "success" : true,
  "scans" : 67,
  "permission_granted" : "granted",
  "cards_detected" : 0,
  "torch_on" : false,
  "orientation" : "portrait",
  "model" : "ssd+apple",
  "duration" : 3.7377920150756836,
  "device_type" : "iPhone13,3",
  "user_canceled" : false
}

```
### Todo: 
*  Move `ScanStats` to encodable