### PR TITLE
Added fix to manually remove target

### DIFF
--- a/CardScan/CardScan/Classes/SimpleScanViewController.swift
+++ b/CardScan/CardScan/Classes/SimpleScanViewController.swift
@@ -142,6 +142,18 @@ import UIKit
         startCameraPreview()
     }
     
+    /* TODO:
+     Removing targets manually since we are allowing custom buttons which retains button reference ->
+     ARC doesn't automatically decrement its reference count ->
+     Targets gets added on every setUpUi call.
+
+     Figure out a better way of allow custom buttons programmatically instead of whole UI buttons.
+    */
+    open override func viewDidDisappear(_ animated: Bool) {
+        closeButton.removeTarget(self, action: #selector(cancelButtonPress), for: .touchUpInside)
+        torchButton.removeTarget(self, action: #selector(torchButtonPress), for: .touchUpInside)
+    }
+    
     @available(iOS 13.0, *)
     func setUpMainLoop(errorCorrectionDuration: Double) {
         if scanPerformancePriority == .accurate {


### PR DESCRIPTION
### Summary
Manually removed the buttons targets at the end of lifecycle due to possible strong referenced custom buttons. 

### Motivation
Afterpay engineer found a bug where after the first open to the view controller, the subsequent calls would cause the app to crash. This is because the custom buttons were strongly referenced and on every subsequent call a new action would be added to the buttons on every `setUpUi()` call. The `x` amount of targets caused the delegate to be called multiple times which caused the crash. 

### Testing Plan
Tested manually with obj-c example app.