### PR TITLE
Cleaning up bounding box logic and surface them

### DIFF
--- a/CardScan/CardScan/Classes/CreditCardOcr/AppleCreditCardOcr.swift
+++ b/CardScan/CardScan/Classes/CreditCardOcr/AppleCreditCardOcr.swift
@@ -10,7 +10,7 @@ import UIKit
 @available(iOS 13.0, *)
 public class AppleCreditCardOcr: CreditCardOcrImplementation {
     public override func recognizeCard(in fullImage: CGImage, roiRectangle: CGRect) -> CreditCardOcrPrediction {
-        guard let image = fullImage.croppedImageForSsd(roiRectangle: roiRectangle) else {
+        guard let (image, roiForOcr) = fullImage.croppedImageForSsd(roiRectangle: roiRectangle) else {
             return CreditCardOcrPrediction.emptyPrediction(cgImage: fullImage)
         }
         
@@ -67,7 +67,7 @@ public class AppleCreditCardOcr: CreditCardOcrImplementation {
         self.computationTime += duration
         self.frames += 1
 
-        return CreditCardOcrPrediction(image: image, number: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, name: name, computationTime: duration, numberBoxes: numberBox.map { [$0] }, expiryBoxes: expiryBox.map { [$0] }, nameBoxes: nameBox.map { [$0] })
+        return CreditCardOcrPrediction(image: image, ocrCroppingRectangle: roiForOcr, number: pan, expiryMonth: expiryMonth, expiryYear: expiryYear, name: name, computationTime: duration, numberBoxes: numberBox.map { [$0] }, expiryBoxes: expiryBox.map { [$0] }, nameBoxes: nameBox.map { [$0] })
     }
     
     static func likelyName(_ text: String) -> String? {

--- a/CardScan/CardScan/Classes/CreditCardOcr/CreditCardOcrPrediction.swift
+++ b/CardScan/CardScan/Classes/CreditCardOcr/CreditCardOcrPrediction.swift
@@ -38,6 +38,7 @@ public enum CenteredCardState {
 
 public struct CreditCardOcrPrediction {
     public let image: CGImage
+    public let ocrCroppingRectangle: CGRect
     public let number: String?
     public let expiryMonth: String?
     public let expiryYear: String?
@@ -51,9 +52,10 @@ public struct CreditCardOcrPrediction {
     public var centeredCardState: CenteredCardState?
     public var uxFrameConfidenceValues: UxFrameConfidenceValues?
     
-    public init(image: CGImage, number: String?, expiryMonth: String?, expiryYear: String?, name: String?, computationTime: Double, numberBoxes: [CGRect]?, expiryBoxes: [CGRect]?, nameBoxes: [CGRect]?, centeredCardState: CenteredCardState? = nil, uxFrameConfidenceValues: UxFrameConfidenceValues? = nil) {
+    public init(image: CGImage, ocrCroppingRectangle: CGRect, number: String?, expiryMonth: String?, expiryYear: String?, name: String?, computationTime: Double, numberBoxes: [CGRect]?, expiryBoxes: [CGRect]?, nameBoxes: [CGRect]?, centeredCardState: CenteredCardState? = nil, uxFrameConfidenceValues: UxFrameConfidenceValues? = nil) {
         
         self.image = image
+        self.ocrCroppingRectangle = ocrCroppingRectangle
         self.number = number
         self.expiryMonth = expiryMonth
         self.expiryYear = expiryYear
@@ -67,7 +69,7 @@ public struct CreditCardOcrPrediction {
     }
     
     public static func emptyPrediction(cgImage: CGImage) -> CreditCardOcrPrediction {
-        CreditCardOcrPrediction(image: cgImage, number: nil, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
+        CreditCardOcrPrediction(image: cgImage, ocrCroppingRectangle: CGRect(), number: nil, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
     }
     
     public var expiryForDisplay: String? {
@@ -92,6 +94,15 @@ public struct CreditCardOcrPrediction {
     
     public var expiryBox: CGRect? {
         return expiryBoxes.flatMap { $0.first }
+    }
+    
+    public var numberBoxesInFullImageFrame: [CGRect]? {
+        guard let boxes = numberBoxes else { return nil }
+        let cropOrigin = ocrCroppingRectangle.origin
+        return boxes.map { CGRect(x: $0.origin.x + cropOrigin.x,
+                                  y: $0.origin.y + cropOrigin.y,
+                                  width: $0.size.width,
+                                  height: $0.size.height) }
     }
     
     static func likelyExpiry(_ string: String) -> (String, String)? {

--- a/CardScan/CardScan/Classes/CreditCardOcr/SSDCreditCardOcr.swift
+++ b/CardScan/CardScan/Classes/CreditCardOcr/SSDCreditCardOcr.swift
@@ -17,7 +17,7 @@ public class SSDCreditCardOcr: CreditCardOcrImplementation {
     
     public override func recognizeCard(in fullImage: CGImage, roiRectangle: CGRect) -> CreditCardOcrPrediction {
 
-        guard let image = fullImage.croppedImageForSsd(roiRectangle: roiRectangle)
+        guard let (image, ocrRoiRectangle) = fullImage.croppedImageForSsd(roiRectangle: roiRectangle)
             else {
                 return CreditCardOcrPrediction.emptyPrediction(cgImage: fullImage)
         }
@@ -29,7 +29,9 @@ public class SSDCreditCardOcr: CreditCardOcrImplementation {
         
         self.computationTime += duration
         self.frames += 1
-        return CreditCardOcrPrediction(image: image, number: number, expiryMonth: nil,
+        return CreditCardOcrPrediction(image: image,
+                                       ocrCroppingRectangle: ocrRoiRectangle,
+                                       number: number, expiryMonth: nil,
                                        expiryYear: nil, name: nil, computationTime: duration,
                                        numberBoxes: numberBoxes, expiryBoxes: nil, nameBoxes: nil)
     }

--- a/CardScan/CardScan/Classes/Extensions/Image+utils.swift
+++ b/CardScan/CardScan/Classes/Extensions/Image+utils.swift
@@ -16,7 +16,7 @@ extension UIImage {
 extension CGImage {
     
     // Crop a full image
-    public func croppedImageForSsd(roiRectangle: CGRect) -> CGImage? {
+    public func croppedImageForSsd(roiRectangle: CGRect) -> (CGImage, CGRect)? {
         
         // add 10% to our ROI rectangle
         let centerX = roiRectangle.origin.x + roiRectangle.size.width * 0.5
@@ -29,8 +29,14 @@ extension CGImage {
         
         let ssdRoiRectangle = CGRect(x: x, y: y, width: width, height: height)
         
-        // if the expanded roi rectangle is too big, fall back to the tight roi rectangle
-        return self.cropping(to: ssdRoiRectangle) ?? self.cropping(to: roiRectangle)
+        if let image = self.cropping(to: ssdRoiRectangle) {
+            return (image, ssdRoiRectangle)
+        } else if let image = self.cropping(to: roiRectangle) {
+            // fall back if the crop was out of bounds
+            return (image, roiRectangle)
+        }
+        
+        return nil
     }
     
     // crop a full image

--- a/CardScan/CardScan/Classes/SSDOcrDetect.swift
+++ b/CardScan/CardScan/Classes/SSDOcrDetect.swift
@@ -135,10 +135,13 @@ struct SSDOcrDetect {
         }
         
         if OcrDDUtils.isQuickRead(allBoxes: DetectedOcrBoxes){
-            return OcrDDUtils.processQuickRead(allBoxes: DetectedOcrBoxes)
-        }
-        else {
-            return OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: DetectedOcrBoxes)
+            guard let (number, boxes) = OcrDDUtils.processQuickRead(allBoxes: DetectedOcrBoxes) else { return nil }
+            self.lastDetectedBoxes = boxes
+            return number
+        } else {
+            guard let (number, boxes) = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: DetectedOcrBoxes) else { return nil }
+            self.lastDetectedBoxes = boxes
+            return number
         }
         
         

--- a/CardScan/CardScan/Classes/ScanBaseViewController.swift
+++ b/CardScan/CardScan/Classes/ScanBaseViewController.swift
@@ -442,12 +442,12 @@ public protocol TestingImageDataSource: AnyObject {
         }
         
         let cardSize = CGSize(width: prediction.image.width, height: prediction.image.height)
-        if let number = prediction.number, let numberBox = prediction.numberBox {
+        if let number = prediction.number, let numberBox = prediction.numberBox, let numberBoxes = prediction.numberBoxesInFullImageFrame {
             let expiry = prediction.expiryObject()
             let expiryBox = prediction.expiryBox
             
             ScanBaseViewController.machineLearningQueue.async {
-                self.scanEventsDelegate?.onNumberRecognized(number: number, expiry: expiry, numberBoundingBox: numberBox, expiryBoundingBox: expiryBox, croppedCardSize: cardSize, squareCardImage: squareCardImage, fullCardImage: fullCardImage, centeredCardState: prediction.centeredCardState, uxFrameConfidenceValues: prediction.uxFrameConfidenceValues, flashForcedOn: isFlashForcedOn)
+                self.scanEventsDelegate?.onNumberRecognized(number: number, expiry: expiry, numberBoundingBox: numberBox, expiryBoundingBox: expiryBox, croppedCardSize: cardSize, squareCardImage: squareCardImage, fullCardImage: fullCardImage, centeredCardState: prediction.centeredCardState, uxFrameConfidenceValues: prediction.uxFrameConfidenceValues, flashForcedOn: isFlashForcedOn, numberBoxesInFullImageFrame: numberBoxes)
             }
         } else {
             ScanBaseViewController.machineLearningQueue.async {

--- a/CardScan/CardScan/Classes/ScanEventsProtocol.swift
+++ b/CardScan/CardScan/Classes/ScanEventsProtocol.swift
@@ -11,7 +11,7 @@ import CoreGraphics
 
 @available(iOS 11.2, *)
 public protocol ScanEvents {
-    mutating func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect, expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool)
+    mutating func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect, expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool, numberBoxesInFullImageFrame: [CGRect])
     mutating func onScanComplete(scanStats: ScanStats)
     mutating func onFrameDetected(croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool)
 }

--- a/CardScanExample/CardScanExample/ViewController.swift
+++ b/CardScanExample/CardScanExample/ViewController.swift
@@ -211,7 +211,7 @@ extension ViewController: SimpleScanDelegate {
 extension ViewController: ScanEvents {
     func onNumberRecognized(number: String, expiry: Expiry?, numberBoundingBox: CGRect,
                             expiryBoundingBox: CGRect?, croppedCardSize: CGSize, squareCardImage:
-                                CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool) {}
+                                CGImage, fullCardImage: CGImage, centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool, numberBoxesInFullImageFrame: [CGRect]) {}
     func onScanComplete(scanStats: ScanStats) {}
     func onFrameDetected(croppedCardSize: CGSize, squareCardImage: CGImage, fullCardImage: CGImage,
                          centeredCardState: CenteredCardState?, uxFrameConfidenceValues: UxFrameConfidenceValues?, flashForcedOn: Bool) {}

--- a/CardScanExample/CardScanExampleTests/CardScan_QuickReadTest.swift
+++ b/CardScanExample/CardScanExampleTests/CardScan_QuickReadTest.swift
@@ -622,7 +622,7 @@ class CardScan_QuickReadTest: XCTestCase {
         var boxes = DetectedAllOcrBoxes()
         boxes.allBoxes = linearNumbers
         
-        guard let number = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
+        guard let (number, _) = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
             XCTFail("testOCRBoxes_LinearNumber: Failed to produce card number")
             return
         }
@@ -635,7 +635,7 @@ class CardScan_QuickReadTest: XCTestCase {
         var boxes = DetectedAllOcrBoxes()
         boxes.allBoxes = visaQuickReadNumbers
         
-        guard let number = OcrDDUtils.processQuickRead(allBoxes: boxes) else {
+        guard let (number, _) = OcrDDUtils.processQuickRead(allBoxes: boxes) else {
             XCTFail("testOCRBoxes_VisaQuickReadNumber: Failed to produce card number")
             return
         }
@@ -648,7 +648,7 @@ class CardScan_QuickReadTest: XCTestCase {
         var boxes = DetectedAllOcrBoxes()
         boxes.allBoxes = linearNumbers_TopLeftBottomRight
         
-        guard let number = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
+        guard let (number, _) = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
             XCTFail("testOCRBoxes_LinearNumberTopLeftBottomRight: Failed to produce card number")
             return
         }
@@ -661,7 +661,7 @@ class CardScan_QuickReadTest: XCTestCase {
         var boxes = DetectedAllOcrBoxes()
         boxes.allBoxes = linearNumbers_BottomLeftTopRight
         
-        guard let number = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
+        guard let (number, _) = OcrDDUtils.sortAndRemoveFalsePositives(allBoxes: boxes) else {
             XCTFail("testOCRBoxes_LinearNumberBottomLeftTopRight: Failed to produce card number")
             return
         }

--- a/CardScanExample/CardScanExampleTests/CardScan_StateMachineTests.swift
+++ b/CardScanExample/CardScanExampleTests/CardScan_StateMachineTests.swift
@@ -23,7 +23,7 @@ class CardScan_StateMachineTests: XCTestCase {
         let durationStateMachine = OcrAccurateMainLoopStateMachine()
         XCTAssert(durationStateMachine.state == .initial)
         
-        let prediction = CreditCardOcrPrediction(image: cardImage, number: number, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
+        let prediction = CreditCardOcrPrediction(image: cardImage, ocrCroppingRectangle: CGRect(), number: number, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
         let state = durationStateMachine.event(prediction: prediction)
         XCTAssert(state == .ocrOnly)
     }
@@ -39,7 +39,7 @@ class CardScan_StateMachineTests: XCTestCase {
         durationStateMachine.state = .ocrOnly
         durationStateMachine.startTimeForCurrentState = Date(timeInterval: minDuration, since: durationStateMachine.startTimeForCurrentState)
         
-        let prediction = CreditCardOcrPrediction(image: cardImage, number: number, expiryMonth: expiryMonth, expiryYear: expiryYear, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
+        let prediction = CreditCardOcrPrediction(image: cardImage, ocrCroppingRectangle: CGRect(), number: number, expiryMonth: expiryMonth, expiryYear: expiryYear, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
         let state = durationStateMachine.event(prediction: prediction)
         
         XCTAssert(state == .finished)
@@ -57,7 +57,7 @@ class CardScan_StateMachineTests: XCTestCase {
         durationStateMachine.state = .ocrOnly
         durationStateMachine.startTimeForCurrentState = Date(timeInterval: maxDuration, since: durationStateMachine.startTimeForCurrentState)
         
-        let prediction = CreditCardOcrPrediction(image: cardImage, number: number, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
+        let prediction = CreditCardOcrPrediction(image: cardImage, ocrCroppingRectangle: CGRect(), number: number, expiryMonth: nil, expiryYear: nil, name: nil, computationTime: 0.0, numberBoxes: nil, expiryBoxes: nil, nameBoxes: nil)
         let state = durationStateMachine.event(prediction: prediction)
         
         XCTAssert(state == .finished)


### PR DESCRIPTION
The new functionality in this PR is to expose bounding boxes for the captured completion loop. We'll use this immediately for redacting captured samples but could be useful later if we want to move to server inference for verify.

This PR also fixes a bug with the way that we used to expose bounding boxes where the new code will use the sorted and filtered boxes instead of the raw boxes from the OCR model.

There will be a companion PR for verify coming soon.

Note: this PR changes a public interface so we'll need to bump to `2.1.0` when we ship it. However, it's very unlikely that anyone other than us is using these interfaces -- the main Scan abstractions are unaffected.